### PR TITLE
Addon catalogs + manifest.behaviorHints

### DIFF
--- a/src/addon_transport/legacy/legacy_manifest.rs
+++ b/src/addon_transport/legacy/legacy_manifest.rs
@@ -114,6 +114,7 @@ impl From<LegacyManifest> for Manifest {
             resources,
             types: m.types,
             catalogs,
+            addon_catalogs: vec![],
             background: m.background,
             logo: m.logo,
             id_prefixes,

--- a/src/addon_transport/legacy/legacy_manifest.rs
+++ b/src/addon_transport/legacy/legacy_manifest.rs
@@ -119,6 +119,9 @@ impl From<LegacyManifest> for Manifest {
             id_prefixes,
             description: m.description,
             contact_email: m.contact_email,
+            // The JS implementation infers `adult`, but it's such a rare case, it's not worth it:
+            // https://github.com/Stremio/stremio-addon-client/blob/4f4dbbf55498d7fdc6bd41bf49cb2f05915b3f8e/lib/transports/legacy/mapper.js#L70
+            behavior_hints: Default::default(),
         }
     }
 }

--- a/src/addon_transport/mod.rs
+++ b/src/addon_transport/mod.rs
@@ -1,7 +1,7 @@
 use crate::state_types::{EnvFuture, Environment, Request};
 use crate::types::addons::*;
-use std::marker::PhantomData;
 use futures::future::err;
+use std::marker::PhantomData;
 
 mod legacy;
 use self::legacy::AddonLegacyTransport;
@@ -34,7 +34,9 @@ impl<T: Environment> AddonInterface for AddonHTTPTransport<T> {
         }
 
         if !self.transport_url.ends_with(MANIFEST_PATH) {
-            return Box::new(err(format!("transport_url must end in {}", MANIFEST_PATH).into()));
+            return Box::new(err(
+                format!("transport_url must end in {}", MANIFEST_PATH).into()
+            ));
         }
 
         let url = self.transport_url.replace(MANIFEST_PATH, &path.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ mod tests {
         assert_eq!(state.selected, Some(req), "selected is right");
         match &state.content {
             Loadable::Ready(x) => assert_eq!(x.len(), 100, "right length of items"),
-            _ => panic!("item_pages[0] is not Ready"),
+            x => panic!("item_pages[0] is not Ready, but instead: {:?}", x),
         }
 
         // Verify that pagination works
@@ -361,7 +361,7 @@ mod tests {
             assert_eq!(model.notifs.groups.len(), 1);
             let meta_items = match &model.notifs.groups[0].content {
                 Loadable::Ready(x) => x,
-                _ => panic!("notifs group not ready"),
+                x => panic!("notifs group not ready, but instead: {:?}", x),
             };
             assert!(meta_items.len() > 1, "should have loaded multiple items");
             // No notifications, cause neither LibItem has .last_vid_released set

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod tests {
     use crate::addon_transport::*;
     use crate::state_types::*;
     use crate::types::addons::{Descriptor, ResourceRef, ResourceRequest, ResourceResponse};
+    use crate::types::MetaPreview;
     use futures::future::lazy;
     use futures::{future, Future};
     use serde::de::DeserializeOwned;
@@ -179,7 +180,7 @@ mod tests {
         #[derive(Model, Debug, Default)]
         struct Model {
             ctx: Ctx<Env>,
-            catalogs: CatalogFiltered,
+            catalogs: CatalogFiltered<MetaPreview>,
         }
 
         let app = Model::default();

--- a/src/state_types/models/catalogs.rs
+++ b/src/state_types/models/catalogs.rs
@@ -60,7 +60,7 @@ impl CatalogAdapter for MetaPreview {
         &m.catalogs
     }
 }
-impl CatalogAdapter for Descriptor {
+impl CatalogAdapter for DescriptorPreview {
     fn resource() -> &'static str {
         "addon_catalog"
     }

--- a/src/state_types/models/catalogs.rs
+++ b/src/state_types/models/catalogs.rs
@@ -71,7 +71,8 @@ pub struct CatalogFiltered<T> {
     pub load_next: Option<ResourceRequest>,
     pub load_prev: Option<ResourceRequest>,
     // If there are defaults, all of them need to be passed to and supported by all catalogs
-    pub default_extras: Vec<ExtraProp>
+    pub default_extras: Vec<ExtraProp>,
+    // 
     // NOTE: There's no currently selected preview item, cause some UIs may not have this
     // so, it should be implemented in the UI
 }
@@ -94,7 +95,10 @@ where
                         let defaults = self.default_extras.clone();
                         a.manifest.catalogs.iter().filter_map(move |cat| {
                             // If there are defaults, all of them need to be supported
-                            if !defaults.iter().all(|x| cat.extra_iter().any(|e| x.0 == e.name)) {
+                            if !defaults
+                                .iter()
+                                .all(|x| cat.extra_iter().find(|e| x.0 == e.name))
+                            {
                                 return None;
                             }
                             // Required properties are allowed, but only if there's .options
@@ -108,7 +112,9 @@ where
                                         .as_ref()
                                         .and_then(|opts| opts.first())
                                         .map(|first| (e.name.to_owned(), first.to_owned()))
-                                        .or_else(|| defaults.iter().find(|x| x.0 == e.name).cloned())
+                                        .or_else(|| {
+                                            defaults.iter().find(|x| x.0 == e.name).cloned()
+                                        })
                                 })
                                 // .collect will return None if at least one of the items in the
                                 // iterator is None

--- a/src/state_types/models/catalogs.rs
+++ b/src/state_types/models/catalogs.rs
@@ -79,8 +79,9 @@ pub struct CatalogFiltered<T> {
     // so, it should be implemented in the UI
 }
 
-impl<Env: Environment + 'static, T> UpdateWithCtx<Ctx<Env>> for CatalogFiltered<T>
+impl<Env, T> UpdateWithCtx<Ctx<Env>> for CatalogFiltered<T>
 where
+    Env: Environment + 'static,
     T: Default + Eq,
     Vec<T>: TryFrom<ResourceResponse>,
 {

--- a/src/state_types/models/catalogs.rs
+++ b/src/state_types/models/catalogs.rs
@@ -99,8 +99,14 @@ impl<Env: Environment + 'static> UpdateWithCtx<Ctx<Env>> for CatalogFiltered {
                                     e.options
                                         .as_ref()
                                         .and_then(|opts| opts.first())
+                                        // @TODO .or_else to fill from defaults that the
+                                        // CatalogFiltered was constructed with
+                                        // although it won't work here, cause we need to filter
+                                        // such that every catalog has the prop
                                         .map(|first| (e.name.to_owned(), first.to_owned()))
                                 })
+                                // .collect will return None if at least one of the items in the
+                                // iterator is None
                                 .collect::<Option<Vec<ExtraProp>>>()?;
                             let load = ResourceRequest {
                                 base: a.transport_url.to_owned(),

--- a/src/state_types/models/catalogs.rs
+++ b/src/state_types/models/catalogs.rs
@@ -3,10 +3,10 @@ use crate::state_types::msg::Internal::*;
 use crate::state_types::*;
 use crate::types::addons::*;
 use crate::types::MetaPreview;
+use derivative::*;
 use itertools::*;
 use serde_derive::*;
 use std::convert::TryFrom;
-use derivative::*;
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct CatalogGrouped {
@@ -48,15 +48,8 @@ pub struct CatalogEntry {
     pub load: ResourceRequest,
 }
 
-#[derive(Serialize, Clone, Debug, PartialEq)]
-pub enum CatalogError {
-    EmptyContent,
-    UnexpectedResp,
-    Other(String),
-}
-
 #[derive(Debug, Clone, Serialize, Derivative)]
-#[derivative(Default(bound=""))]
+#[derivative(Default(bound = ""))]
 pub struct CatalogFiltered<T> {
     pub types: Vec<TypeEntry>,
     pub catalogs: Vec<CatalogEntry>,

--- a/src/state_types/models/catalogs.rs
+++ b/src/state_types/models/catalogs.rs
@@ -6,6 +6,7 @@ use crate::types::MetaPreview;
 use itertools::*;
 use serde_derive::*;
 use std::convert::TryFrom;
+use derivative::*;
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct CatalogGrouped {
@@ -54,7 +55,8 @@ pub enum CatalogError {
     Other(String),
 }
 
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Derivative)]
+#[derivative(Default(bound=""))]
 pub struct CatalogFiltered<T> {
     pub types: Vec<TypeEntry>,
     pub catalogs: Vec<CatalogEntry>,
@@ -82,7 +84,7 @@ pub struct CatalogFiltered<T> {
 impl<Env, T> UpdateWithCtx<Ctx<Env>> for CatalogFiltered<T>
 where
     Env: Environment + 'static,
-    T: Default + Eq,
+    T: PartialEq,
     Vec<T>: TryFrom<ResourceResponse>,
 {
     fn update(&mut self, ctx: &Ctx<Env>, msg: &Msg) -> Effects {

--- a/src/state_types/models/catalogs.rs
+++ b/src/state_types/models/catalogs.rs
@@ -72,7 +72,7 @@ pub struct CatalogFiltered<T> {
     pub load_prev: Option<ResourceRequest>,
     // If there are defaults, all of them need to be passed to and supported by all catalogs
     pub default_extras: Vec<ExtraProp>,
-    // 
+    //
     // NOTE: There's no currently selected preview item, cause some UIs may not have this
     // so, it should be implemented in the UI
 }
@@ -92,15 +92,15 @@ where
                 let catalogs: Vec<CatalogEntry> = addons
                     .iter()
                     .flat_map(|a| {
-                        let defaults = self.default_extras.clone();
-                        a.manifest.catalogs.iter().filter_map(move |cat| {
-                            // If there are defaults, all of them need to be supported
-                            if !defaults
+                        // If there are defaults, all of them need to be supported
+                        let catalogs = a.manifest.catalogs.iter().filter(|cat| {
+                            self.default_extras
                                 .iter()
-                                .all(|x| cat.extra_iter().find(|e| x.0 == e.name))
-                            {
-                                return None;
-                            }
+                                .all(|x| cat.extra_iter().any(|e| x.0 == e.name))
+                        });
+                        let defaults = self.default_extras.clone();
+
+                        catalogs.filter_map(move |cat| {
                             // Required properties are allowed, but only if there's .options
                             // with at least one option inside (that we default to)
                             // If there are no required properties at all, this will resolve to Some([])

--- a/src/state_types/models/catalogs.rs
+++ b/src/state_types/models/catalogs.rs
@@ -157,12 +157,6 @@ impl<Env: Environment + 'static> UpdateWithCtx<Ctx<Env>> for CatalogFiltered {
                 };
                 Effects::one(addon_get::<Env>(&selected_req))
             }
-            // can't use items_group here
-            // cause we 1) do other things (load_prev/load_next) after we've matched .selected
-            // (could be mitigated)
-            // 2) keep .selected in the model, not in the group (could just be moved tho)
-            // 3) hardest one to mitigate is that we .iter().take(PAGE_LEN as usize) ...
-            //   if we decide we don't need that, then we can reuse
             Msg::Internal(AddonResponse(req, resp))
                 if Some(req) == self.selected.as_ref() && self.content == Loadable::Loading =>
             {

--- a/src/state_types/models/items_group.rs
+++ b/src/state_types/models/items_group.rs
@@ -1,8 +1,14 @@
-use super::CatalogError;
 use crate::state_types::*;
 use crate::types::addons::{Descriptor, ResourceRequest, ResourceResponse};
 use serde_derive::*;
 use std::convert::TryInto;
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub enum CatalogError {
+    EmptyContent,
+    UnexpectedResp,
+    Other(String),
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type", content = "content")]

--- a/src/state_types/models/items_group.rs
+++ b/src/state_types/models/items_group.rs
@@ -39,6 +39,8 @@ where
         }
     }
     fn update(&mut self, res: &Result<ResourceResponse, EnvError>) {
+        // NOTE: Not using CatalogError::EmptyContent here is intentional
+        // this is not an error for the ItemsGroup
         self.content = match res {
             Ok(resp) => match resp.to_owned().try_into() {
                 Ok(x) => Loadable::Ready(x),

--- a/src/state_types/models/items_group.rs
+++ b/src/state_types/models/items_group.rs
@@ -2,8 +2,7 @@ use crate::state_types::*;
 use crate::types::addons::{Descriptor, ResourceRequest, ResourceResponse};
 use serde_derive::*;
 use std::convert::TryInto;
-
-pub const UNEXPECTED_RESP_MSG: &str = "unexpected ResourceResponse";
+use super::CatalogError;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type", content = "content")]
@@ -21,8 +20,7 @@ impl<R, E> Default for Loadable<R, E> {
 #[derive(Debug, Serialize, Clone)]
 pub struct ItemsGroup<T> {
     req: ResourceRequest,
-    // @TODO: Use the CatalogError type
-    pub content: Loadable<T, String>,
+    pub content: Loadable<T, CatalogError>,
 }
 impl<T> Group for ItemsGroup<T>
 where
@@ -38,9 +36,9 @@ where
         self.content = match res {
             Ok(resp) => match resp.to_owned().try_into() {
                 Ok(x) => Loadable::Ready(x),
-                Err(_) => Loadable::Err(UNEXPECTED_RESP_MSG.to_string()),
+                Err(_) => Loadable::Err(CatalogError::UnexpectedResp),
             },
-            Err(e) => Loadable::Err(e.to_string()),
+            Err(e) => Loadable::Err(CatalogError::Other(e.to_string())),
         };
     }
     fn addon_req(&self) -> &ResourceRequest {

--- a/src/state_types/models/items_group.rs
+++ b/src/state_types/models/items_group.rs
@@ -1,8 +1,8 @@
+use super::CatalogError;
 use crate::state_types::*;
 use crate::types::addons::{Descriptor, ResourceRequest, ResourceResponse};
 use serde_derive::*;
 use std::convert::TryInto;
-use super::CatalogError;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type", content = "content")]

--- a/src/state_types/models/items_group.rs
+++ b/src/state_types/models/items_group.rs
@@ -21,6 +21,7 @@ impl<R, E> Default for Loadable<R, E> {
 #[derive(Debug, Serialize, Clone)]
 pub struct ItemsGroup<T> {
     req: ResourceRequest,
+    // @TODO: Use the CatalogError type
     pub content: Loadable<T, String>,
 }
 impl<T> Group for ItemsGroup<T>

--- a/src/types/addons/manifest.rs
+++ b/src/types/addons/manifest.rs
@@ -72,6 +72,8 @@ impl Default for ManifestExtra {
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ManifestCatalog {
+    // #[serde(rename = "resource", default = "String::new("catalog")")]
+    // pub resource_name: String,
     #[serde(rename = "type")]
     pub type_name: String,
     pub id: String,

--- a/src/types/addons/manifest.rs
+++ b/src/types/addons/manifest.rs
@@ -120,8 +120,8 @@ pub struct ManifestPreview {
 }
 
 // The manifest itself
-// @TODO consider separating the meta in .meta (#[serde(flatten)]), in order to be able to
-// construct a manifest from meta + addon builder separately
+// If we construct the addon with a builder, we can only take ManifestPreview
+// and fill in the rest
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Manifest {
@@ -137,8 +137,8 @@ pub struct Manifest {
     pub id_prefixes: Option<Vec<String>>,
     #[serde(default)]
     pub catalogs: Vec<ManifestCatalog>,
-    // @TODO: implement that, consider a more efficient data structure
-    //pub behavior_hints: Vec<String>,
+    #[serde(default)]
+    pub behavior_hints: serde_json::Map<String, serde_json::Value>,
 }
 
 impl Manifest {

--- a/src/types/addons/manifest.rs
+++ b/src/types/addons/manifest.rs
@@ -138,6 +138,8 @@ pub struct Manifest {
     #[serde(default)]
     pub catalogs: Vec<ManifestCatalog>,
     #[serde(default)]
+    pub addon_catalogs: Vec<ManifestCatalog>,
+    #[serde(default)]
     pub behavior_hints: serde_json::Map<String, serde_json::Value>,
 }
 

--- a/src/types/addons/manifest.rs
+++ b/src/types/addons/manifest.rs
@@ -107,6 +107,18 @@ impl ManifestCatalog {
     }
 }
 
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestPreview {
+    pub id: String,
+    pub version: Version,
+    pub name: String,
+    pub description: Option<String>,
+    pub logo: Option<String>,
+    pub background: Option<String>,
+    pub types: Vec<String>,
+}
+
 // The manifest itself
 // @TODO consider separating the meta in .meta (#[serde(flatten)]), in order to be able to
 // construct a manifest from meta + addon builder separately
@@ -120,8 +132,8 @@ pub struct Manifest {
     pub description: Option<String>,
     pub logo: Option<String>,
     pub background: Option<String>,
-    pub resources: Vec<ManifestResource>,
     pub types: Vec<String>,
+    pub resources: Vec<ManifestResource>,
     pub id_prefixes: Option<Vec<String>>,
     #[serde(default)]
     pub catalogs: Vec<ManifestCatalog>,

--- a/src/types/addons/manifest.rs
+++ b/src/types/addons/manifest.rs
@@ -72,8 +72,6 @@ impl Default for ManifestExtra {
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ManifestCatalog {
-    // #[serde(rename = "resource", default = "String::new("catalog")")]
-    // pub resource_name: String,
     #[serde(rename = "type")]
     pub type_name: String,
     pub id: String,

--- a/src/types/addons/manifest_tests.rs
+++ b/src/types/addons/manifest_tests.rs
@@ -15,6 +15,7 @@ mod tests {
             resources,
             types: vec!["movie".into()],
             catalogs: vec![],
+            addon_catalogs: vec![],
             contact_email: None,
             background: None,
             logo: None,

--- a/src/types/addons/manifest_tests.rs
+++ b/src/types/addons/manifest_tests.rs
@@ -20,7 +20,7 @@ mod tests {
             logo: None,
             id_prefixes,
             description: None,
-            behavior_hints: Default::default()
+            behavior_hints: Default::default(),
         }
     }
 

--- a/src/types/addons/manifest_tests.rs
+++ b/src/types/addons/manifest_tests.rs
@@ -20,6 +20,7 @@ mod tests {
             logo: None,
             id_prefixes,
             description: None,
+            behavior_hints: Default::default()
         }
     }
 

--- a/src/types/addons/mod.rs
+++ b/src/types/addons/mod.rs
@@ -54,6 +54,9 @@ pub enum ResourceResponse {
     },
     Subtitles {
         subtitles: Vec<SubtitlesSource>,
+    },
+    Addons {
+        addons: Vec<Descriptor>
     }
 }
 

--- a/src/types/addons/mod.rs
+++ b/src/types/addons/mod.rs
@@ -56,8 +56,8 @@ pub enum ResourceResponse {
         subtitles: Vec<SubtitlesSource>,
     },
     Addons {
-        addons: Vec<Descriptor>
-    }
+        addons: Vec<Descriptor>,
+    },
 }
 
 // This is going from the most general to the most concrete aggregation request

--- a/src/types/addons/mod.rs
+++ b/src/types/addons/mod.rs
@@ -11,6 +11,13 @@ pub type TransportUrl = String;
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DescriptorPreview {
+    pub manifest: ManifestPreview,
+    pub transport_url: TransportUrl,
+}
+
+#[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Descriptor {
     pub manifest: Manifest,
     pub transport_url: TransportUrl,
@@ -56,7 +63,7 @@ pub enum ResourceResponse {
         subtitles: Vec<SubtitlesSource>,
     },
     Addons {
-        addons: Vec<Descriptor>,
+        addons: Vec<DescriptorPreview>,
     },
 }
 


### PR DESCRIPTION
Implements an ability for addons to provide catalogs with addons, therefore adding the addon repository feature to Stremio

See https://github.com/Stremio/stremio-core/issues/28

This option seems least cumbersome to implement: "alternatively, addon catalogs will be hidden behind a required property, and we will instantiate CatalogFiltered with some extra prop already passed;"

Others have problems: `.addon_catalogs` requires another generic trait, makes things much more complicated, for essentially what is the same data structure as `.catalogs`; as for `resource_name`, it's weird cause `.catalogs` implies a `catalog` resource

Checklist:

* [x] `items_group` should use `CatalogError`
* [x] consider using `items_group` for `CatalogFiltered` or alternatively use `try_from` directly, to make it polymorphic
* [ ] preview `Descriptor` or generic `Descriptor`
* [ ] implement `CatalogAdapter` and `manifest.addon_catalogs`