### PR TITLE
env-web compatible with stable Rust

### DIFF
--- a/env-web/Cargo.toml
+++ b/env-web/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "^1.0.85", features = ["derive"] }
-wasm-bindgen = { version = "0.2.40", features = ["serde-serialize", "nightly"]  }
+wasm-bindgen = { version = "0.2.40", features = ["serde-serialize"]  }
 futures = "0.1"
 serde_json = "1.0.16"
 wasm-bindgen-futures = "0.3"

--- a/env-web/src/lib.rs
+++ b/env-web/src/lib.rs
@@ -73,10 +73,7 @@ impl Env {
             None => None,
         })
     }
-    fn set_storage_sync<T: Serialize>(
-        key: &str,
-        value: Option<&T>,
-    ) -> Result<(), EnvError> {
+    fn set_storage_sync<T: Serialize>(key: &str, value: Option<&T>) -> Result<(), EnvError> {
         let storage = Self::get_storage()?;
         match value {
             Some(v) => {
@@ -124,9 +121,7 @@ impl Environment for Env {
                     // @TODO: optimize this, as this is basically deserializing in JS -> serializing in
                     // JS -> deserializing in rust
                     // NOTE: there's no realistic scenario those unwraps fail
-                    future::Either::A(
-                        JsFuture::from(resp.json().unwrap()).map_err(EnvError::from),
-                    )
+                    future::Either::A(JsFuture::from(resp.json().unwrap()).map_err(EnvError::from))
                 } else {
                     future::Either::B(future::err(EnvError::HTTPStatusCode(resp.status())))
                 }


### PR DESCRIPTION
Changes
 - Feature `nightly` removed from `wasm-bindgen` in `env-web`.
   - So we can use Seed with stable Rust
- Clippy warnings are resolved.
- Formatted.

Tests
  - `cargo test`
  - with `stremio-seed-poc`