### PR TITLE
Alias for stremio-core

### DIFF
--- a/stremio-derive/Cargo.toml
+++ b/stremio-derive/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = "0.15.23"
-quote = "0.6.10"
+syn = "1.0"
+quote = "1.0"
+proc-macro2 = "1.0"
+proc-macro-crate = "0.1.4"
 

--- a/stremio-derive/src/lib.rs
+++ b/stremio-derive/src/lib.rs
@@ -1,12 +1,25 @@
 extern crate proc_macro;
 use crate::proc_macro::TokenStream;
 
+use proc_macro2::Span;
+use proc_macro_crate::crate_name;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
-use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Fields, FieldsNamed};
+use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Fields, FieldsNamed, Ident};
+
+const CORE_CRATE_ORIGINAL_NAME: &str = "stremio-core";
 
 #[proc_macro_derive(Model)]
 pub fn model_derive(input: TokenStream) -> TokenStream {
+    // `$crate` alternative for proc macros (https://github.com/rust-lang/rust/issues/54363)
+    let core_crate_name = crate_name(CORE_CRATE_ORIGINAL_NAME).unwrap_or_else(|_| {
+        panic!(
+            "crate `{}` has to be included in dependencies in `Cargo.toml`",
+            CORE_CRATE_ORIGINAL_NAME
+        )
+    });
+    let core = Ident::new(&core_crate_name, Span::call_site());
+
     let input = parse_macro_input!(input as DeriveInput);
 
     if let Data::Struct(DataStruct {
@@ -25,13 +38,13 @@ pub fn model_derive(input: TokenStream) -> TokenStream {
         let container_updates = fields.map(|f| {
             let name = &f.ident;
             quote_spanned! {f.span() =>
-                .join(crate::state_types::UpdateWithCtx::update(&mut self.#name, &self.ctx, msg))
+                .join(#core::state_types::UpdateWithCtx::update(&mut self.#name, &self.ctx, msg))
             }
         });
         let expanded = quote! {
-            impl crate::state_types::Update for #name {
-                fn update(&mut self, msg: &crate::state_types::Msg) -> crate::state_types::Effects {
-                    crate::state_types::Update::update(&mut self.ctx, msg)
+            impl #core::state_types::Update for #name {
+                fn update(&mut self, msg: &#core::state_types::Msg) -> #core::state_types::Effects {
+                    #core::state_types::Update::update(&mut self.ctx, msg)
                         #(#container_updates)*
                 }
             }


### PR DESCRIPTION
**Motivation**
Remove
```rust
// required to make stremio_derive work :(
pub use stremio_core::state_types;
```
from projects with `#[derive(Model)]` (e.g. [stremio-seed-poc/src/lib.rs](https://github.com/Stremio/stremio-seed-poc/blob/master/src/lib.rs#L4))

**Changes**
- `crate::**` changed to `#core::**` in `quote!`
   - where `#core` is `Ident` generated by library `proc-macro-crate` - `#core` is the original name (`stremio-core`) or user-defined alias in user's `Cargo.toml`.
   - We can use `stremio_core::**` instead of `#core`, but it would be more error-prone.
- Updated `syn` and `quote` versions to resolve version conflicts.

**Tests**
- `cargo test`
- `cargo clippy`
- Build with `stremio-seed-poc`