### PR TITLE
Fix/crate name and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: rust
+rust:
+  - stable
+
+os:
+  - linux
+
+jobs:
+    fast_finish: true
+
+cache: cargo
+
+env:
+  global:
+    - RUST_BACKTRACE=1
+
+install:
+  - rustup component add rustfmt
+  - rustup component add clippy
+
+script:
+  - cargo fmt --all -- --check
+  - cargo clippy --all
+  - cargo test --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ install:
 
 script:
   - cargo fmt --all -- --check
-  - cargo clippy --all
+  - cargo clippy --all -- -D warnings
   - cargo test --all

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-enum-variant-size-threshold = 400
+enum-variant-size-threshold = 550

--- a/src/state_types/models/context.rs
+++ b/src/state_types/models/context.rs
@@ -105,9 +105,17 @@ impl<Env: Environment + 'static> Update for Ctx<Env> {
                         None => Effects::msg(CtxUpdate(new_content).into()).unchanged(),
                     }
                 }
-                ActionUser::Register { email, password, gdpr_consent } => Effects::one(authenticate::<Env>(
+                ActionUser::Register {
+                    email,
+                    password,
+                    gdpr_consent,
+                } => Effects::one(authenticate::<Env>(
                     action.to_owned(),
-                    APIRequest::Register { email, password, gdpr_consent },
+                    APIRequest::Register {
+                        email,
+                        password,
+                        gdpr_consent,
+                    },
                 ))
                 .unchanged(),
                 ActionUser::Login { email, password } => Effects::one(authenticate::<Env>(

--- a/src/state_types/msg/actions.rs
+++ b/src/state_types/msg/actions.rs
@@ -1,8 +1,8 @@
-use crate::types::addons::*;
-use crate::types::LibItem;
 use crate::state_types::{Settings, StreamingServerSettings};
-use serde_derive::*;
+use crate::types::addons::*;
 use crate::types::api::GDPRConsent;
+use crate::types::LibItem;
+use serde_derive::*;
 
 //
 // Input actions: those are triggered by users
@@ -10,10 +10,19 @@ use crate::types::api::GDPRConsent;
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(tag = "load", content = "args")]
 pub enum ActionLoad {
-    CatalogGrouped { extra: Vec<ExtraProp> },
+    CatalogGrouped {
+        extra: Vec<ExtraProp>,
+    },
     CatalogFiltered(ResourceRequest),
-    Detail { type_name: String, id: String, video_id: Option<String> },
-    Streams { type_name: String, id: String },
+    Detail {
+        type_name: String,
+        id: String,
+        video_id: Option<String>,
+    },
+    Streams {
+        type_name: String,
+        id: String,
+    },
     Notifications,
 }
 
@@ -37,8 +46,15 @@ pub enum ActionSettings {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(tag = "userOp", content = "args")]
 pub enum ActionUser {
-    Login { email: String, password: String },
-    Register { email: String, password: String, gdpr_consent: GDPRConsent },
+    Login {
+        email: String,
+        password: String,
+    },
+    Register {
+        email: String,
+        password: String,
+        gdpr_consent: GDPRConsent,
+    },
     Logout,
     PullAndUpdateAddons,
     PushAddons,

--- a/src/state_types/msg/mod.rs
+++ b/src/state_types/msg/mod.rs
@@ -2,9 +2,9 @@ use crate::state_types::{CtxContent, EnvError, SsSettings};
 use crate::types::addons::*;
 use crate::types::api::*;
 use crate::types::{LibBucket, Stream};
+use derive_more::*;
 use serde_derive::*;
 use std::error::Error;
-use derive_more::*;
 
 mod actions;
 pub use actions::*;

--- a/src/types/api/mod.rs
+++ b/src/types/api/mod.rs
@@ -27,7 +27,7 @@ pub struct GDPRConsent {
     pub privacy: bool,
     pub marketing: bool,
     pub time: DateTime<Utc>,
-    pub from: String
+    pub from: String,
 }
 
 #[derive(Serialize, Clone)]

--- a/stremio-derive/src/lib.rs
+++ b/stremio-derive/src/lib.rs
@@ -4,10 +4,10 @@ use crate::proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_crate::crate_name;
 use quote::{quote, quote_spanned};
+use std::borrow::Cow;
+use std::env;
 use syn::spanned::Spanned;
 use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Fields, FieldsNamed, Ident};
-use std::env;
-use std::borrow::Cow;
 
 const CORE_CRATE_ORIGINAL_NAME: &str = "stremio-core";
 

--- a/stremio-derive/src/lib.rs
+++ b/stremio-derive/src/lib.rs
@@ -6,14 +6,14 @@ use proc_macro_crate::crate_name;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Fields, FieldsNamed, Ident};
+use std::env;
+use std::borrow::Cow;
 
 const CORE_CRATE_ORIGINAL_NAME: &str = "stremio-core";
 
 #[proc_macro_derive(Model)]
 pub fn model_derive(input: TokenStream) -> TokenStream {
-    // `$crate` alternative for proc macros (https://github.com/rust-lang/rust/issues/54363)
-    let core_crate_name = crate_name(CORE_CRATE_ORIGINAL_NAME).unwrap_or("crate".to_owned());
-    let core = Ident::new(&core_crate_name, Span::call_site());
+    let core = core_ident().unwrap();
     let input = parse_macro_input!(input as DeriveInput);
 
     if let Data::Struct(DataStruct {
@@ -48,4 +48,20 @@ pub fn model_derive(input: TokenStream) -> TokenStream {
     } else {
         panic!("#[derive(Model)] is only defined for structs with named fields");
     }
+}
+
+/// Get `stremio-core` crate alias to use in proc macro.
+/// # Errors
+/// ```text
+/// "Could not find `stremio-core` in `dependencies` or `dev-dependencies` in `stremio-seed-poc/Cargo.toml`!"
+/// ```
+fn core_ident() -> Result<Ident, String> {
+    let in_itself = env::var("CARGO_PKG_NAME").unwrap() == CORE_CRATE_ORIGINAL_NAME;
+    let core_crate_name = if in_itself {
+        Cow::Borrowed("crate")
+    } else {
+        // `crate_name` is a `$crate` alternative for proc macros (https://github.com/rust-lang/rust/issues/54363)
+        Cow::Owned(crate_name(CORE_CRATE_ORIGINAL_NAME)?)
+    };
+    Ok(Ident::new(&core_crate_name, Span::call_site()))
 }


### PR DESCRIPTION
Fixes #125 

---

`.travis.yml` - I use pedantic clippy in my projects, example from Seed's repo:
```toml
command = "cargo"
args = ["clippy", "--all-features", "--", "--deny", "warnings", "--deny", "clippy::pedantic", "--deny", "clippy::nursery"]
```
=> can I add the similar command also into this project?
There is only `cargo clippy --all` in the current `.travis.yml` so clippy warnings are basically ignored.

---

And there are one clippy warning:
<details>
<summary>warning content</summary>

```
warning: large size difference between variants
  --> src\types\addons\mod.rs:65:5
   |
65 | /     Meta {
66 | |         // NOTE: we are not putting this in Option<>, since that way it gives us a valid
67 | |         // fallback to all of the previous variants, therefore resulting in inaccurate err messages
68 | |         // To support other /meta/ responses (meta extensions), we should make a MetaExt variant
69 | |         meta: MetaDetail,
70 | |     },
   | |_____^
   |
   = note: `#[warn(clippy::large_enum_variant)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_en
um_variant
help: consider boxing the large fields to reduce the total size of the enum
   |
69 |         meta: Box<MetaDetail>,
   |               ^^^^^^^^^^^^^^^

```
</details>

How do you want to resolve it?
- Add `Box`
- Decorate with `#[allow(clippy::...`
- Change size threshold