### PR TITLE
Implement and add streams bucket

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,6 +8,7 @@ pub const SCHEMA_VERSION_STORAGE_KEY: &str = "schema_version";
 pub const PROFILE_STORAGE_KEY: &str = "profile";
 pub const LIBRARY_STORAGE_KEY: &str = "library";
 pub const LIBRARY_RECENT_STORAGE_KEY: &str = "library_recent";
+pub const STREAMS_STORAGE_KEY: &str = "streams";
 pub const LIBRARY_COLLECTION_NAME: &str = "libraryItem";
 pub const SEARCH_EXTRA_NAME: &str = "search";
 pub const META_RESOURCE_NAME: &str = "meta";

--- a/src/models/ctx/mod.rs
+++ b/src/models/ctx/mod.rs
@@ -4,6 +4,8 @@ use update_library::*;
 mod update_profile;
 use update_profile::*;
 
+mod update_streams;
+
 mod error;
 pub use error::*;
 

--- a/src/models/ctx/update_profile.rs
+++ b/src/models/ctx/update_profile.rs
@@ -248,13 +248,13 @@ pub fn update_profile<E: Env + 'static>(
             (CtxStatus::Loading(loading_auth_request), Ok((auth, addons, _)))
                 if loading_auth_request == auth_request =>
             {
-                let next_proifle = Profile {
+                let next_profile = Profile {
                     auth: Some(auth.to_owned()),
                     addons: addons.to_owned(),
                     settings: Settings::default(),
                 };
-                if *profile != next_proifle {
-                    *profile = next_proifle;
+                if *profile != next_profile {
+                    *profile = next_profile;
                     Effects::msg(Msg::Internal(Internal::ProfileChanged))
                 } else {
                     Effects::none().unchanged()

--- a/src/models/ctx/update_streams.rs
+++ b/src/models/ctx/update_streams.rs
@@ -1,0 +1,85 @@
+use enclose::enclose;
+use futures::FutureExt;
+
+use crate::constants::STREAMS_STORAGE_KEY;
+use crate::models::ctx::{CtxError, CtxStatus};
+use crate::models::player::Selected;
+use crate::runtime::msg::{Action, ActionCtx, ActionLoad, Event, Internal, Msg};
+use crate::runtime::{Effect, EffectFuture, Effects, Env, EnvFutureExt};
+use crate::types::addon::{ResourcePath, ResourceRequest};
+use crate::types::library::{StreamBucketItem, StreamsBucket};
+
+pub fn update_streams<E: Env + 'static>(
+    streams: &mut StreamsBucket,
+    status: &CtxStatus,
+    msg: &Msg,
+) -> Effects {
+    match msg {
+        Msg::Action(Action::Ctx(ActionCtx::Logout)) => {
+            let next_streams = StreamsBucket::default();
+            if *streams != next_streams {
+                *streams = next_streams;
+                Effects::msg(Msg::Internal(Internal::StreamsChanged(false)))
+            } else {
+                Effects::none().unchanged()
+            }
+        }
+        Msg::Action(Action::Load(ActionLoad::Player(Selected {
+            stream,
+            stream_request:
+                Some(ResourceRequest {
+                    base: stream_addon_url,
+                    path: ResourcePath { id: video_id, .. },
+                }),
+            meta_request:
+                Some(ResourceRequest {
+                    path: ResourcePath { id: meta_id, .. },
+                    ..
+                }),
+            ..
+        }))) => {
+            let bucket_item = StreamBucketItem {
+                stream: stream.to_owned(),
+                stream_addon_url: stream_addon_url.to_owned(),
+                last_modified: E::now(),
+            };
+            streams
+                .items
+                .insert((meta_id.to_owned(), video_id.to_owned()), bucket_item);
+            Effects::msg(Msg::Internal(Internal::StreamsChanged(false)))
+        }
+        Msg::Internal(Internal::StreamsChanged(persisted)) if !persisted => {
+            Effects::one(push_streams_to_storage::<E>(streams)).unchanged()
+        }
+        Msg::Internal(Internal::CtxAuthResult(auth_request, result)) => match (status, result) {
+            (CtxStatus::Loading(loading_auth_request), Ok((auth, _, _)))
+                if loading_auth_request == auth_request =>
+            {
+                let next_streams = StreamsBucket::new(Some(auth.user.id.to_owned()));
+                if *streams != next_streams {
+                    *streams = next_streams;
+                    Effects::msg(Msg::Internal(Internal::StreamsChanged(false)))
+                } else {
+                    Effects::none().unchanged()
+                }
+            }
+            _ => Effects::none().unchanged(),
+        },
+        _ => Effects::none().unchanged(),
+    }
+}
+
+fn push_streams_to_storage<E: Env + 'static>(streams: &StreamsBucket) -> Effect {
+    EffectFuture::Sequential(
+        E::set_storage(STREAMS_STORAGE_KEY, Some(&streams))
+            .map(enclose!((streams.uid => uid) move |result| match result {
+                Ok(_) => Msg::Event(Event::StreamsPushedToStorage { uid }),
+                Err(error) => Msg::Event(Event::Error {
+                    error: CtxError::from(error),
+                    source: Box::new(Event::StreamsPushedToStorage { uid }),
+                })
+            }))
+            .boxed_env(),
+    )
+    .into()
+}

--- a/src/runtime/msg/event.rs
+++ b/src/runtime/msg/event.rs
@@ -13,6 +13,7 @@ use url::Url;
 pub enum Event {
     ProfilePushedToStorage { uid: UID },
     LibraryItemsPushedToStorage { ids: Vec<String> },
+    StreamsPushedToStorage { uid: UID },
     UserPulledFromAPI { uid: UID },
     UserPushedToAPI { uid: UID },
     AddonsPulledFromAPI { transport_urls: Vec<Url> },

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -38,6 +38,8 @@ pub enum Internal {
     ProfileChanged,
     // Dispatched when library changes with a flag if its already persisted.
     LibraryChanged(bool),
+    // Dispatched when streams bucket changes with a flag if its already persisted.
+    StreamsChanged(bool),
     // Result for loading link code.
     LinkCodeResult(Result<LinkCodeResponse, LinkError>),
     // Result for loading link data.

--- a/src/types/library/library_item.rs
+++ b/src/types/library/library_item.rs
@@ -99,7 +99,6 @@ pub struct LibraryItemState {
     #[serde(default, rename = "video_id")]
     #[serde_as(deserialize_as = "DefaultOnNull<NoneAsEmptyString>")]
     pub video_id: Option<String>,
-    // @TODO bitfield, special type
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull<NoneAsEmptyString>")]
     pub watched: Option<String>,

--- a/src/types/library/mod.rs
+++ b/src/types/library/mod.rs
@@ -3,3 +3,6 @@ pub use library_bucket::*;
 
 mod library_item;
 pub use library_item::*;
+
+mod stream_bucket;
+pub use stream_bucket::*;

--- a/src/types/library/stream_bucket.rs
+++ b/src/types/library/stream_bucket.rs
@@ -1,0 +1,42 @@
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use url::Url;
+
+use crate::types::profile::UID;
+use crate::types::resource::Stream;
+
+#[serde_as]
+#[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct StreamsBucket {
+    pub uid: UID,
+    #[serde_as(as = "Vec<(_, _)>")]
+    pub items: HashMap<(String, String), StreamBucketItem>,
+}
+
+#[serde_as]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct StreamBucketItem {
+    pub stream: Stream,
+    pub stream_addon_url: Url,
+    pub last_modified: DateTime<Utc>,
+}
+
+impl StreamsBucket {
+    pub fn new(uid: UID) -> Self {
+        StreamsBucket {
+            uid,
+            items: HashMap::new(),
+        }
+    }
+    pub fn merge_bucket(&mut self, bucket: StreamsBucket) {
+        if self.uid == bucket.uid {
+            self.items
+                .extend(bucket.items.into_iter().map(|(k, v)| (k, v)));
+        };
+    }
+}


### PR DESCRIPTION
Closes #65 

Just not sure if we should overwrite and erase currently existing `StreamsBucket` when a new login is successful, since these are not persisted in the API like `LibraryBucket`, so we'd loose this info. Maybe it would be better to keep the `StreamsBucket` global for the installation, regardless of the user?