### PR TITLE
do not return streams deeplink for lib item with dismissed video

### DIFF
--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -99,6 +99,7 @@ impl From<&LibraryItem> for LibraryItemDeepLinks {
                 .state
                 .video_id
                 .as_ref()
+                .filter(|_video_id| item.state.time_offset > 0)
                 .or(item.behavior_hints.default_video_id.as_ref())
                 .map(|video_id| {
                     format!(

--- a/src/unit_tests/deep_links/library_item_deep_links.rs
+++ b/src/unit_tests/deep_links/library_item_deep_links.rs
@@ -45,7 +45,7 @@ fn library_item_deep_links() {
 }
 
 #[test]
-fn library_item_deep_links_state_video_id() {
+fn library_item_deep_links_state_video_id_no_time_offset() {
     // With state.video_id
     let lib_item = LibraryItem {
         id: "tt1254207".to_string(),
@@ -61,6 +61,44 @@ fn library_item_deep_links_state_video_id() {
             last_watched: None,
             time_watched: 999,
             time_offset: 0,
+            overall_time_watched: 999,
+            times_watched: 999,
+            flagged_watched: 1,
+            duration: 0,
+            video_id: Some("video_id".to_string()),
+            watched: None,
+            last_vid_released: None,
+            no_notif: true,
+        },
+        behavior_hints: Default::default(),
+    };
+    let lidl = LibraryItemDeepLinks::try_from(&lib_item).unwrap();
+    assert_eq!(
+        lidl.meta_details_videos,
+        Some(META_DETAILS_VIDEOS.to_string())
+    );
+    assert_eq!(lidl.meta_details_streams, None);
+    assert_eq!(lidl.player, None);
+    assert_eq!(lidl.external_player, None);
+}
+
+#[test]
+fn library_item_deep_links_state_video_id() {
+    // With state.video_id
+    let lib_item = LibraryItem {
+        id: "tt1254207".to_string(),
+        name: "movie".to_string(),
+        r#type: "movie".to_string(),
+        poster: None,
+        poster_shape: PosterShape::Poster,
+        removed: false,
+        temp: true,
+        ctime: None,
+        mtime: Utc::now(),
+        state: LibraryItemState {
+            last_watched: None,
+            time_watched: 999,
+            time_offset: 1,
             overall_time_watched: 999,
             times_watched: 999,
             flagged_watched: 1,
@@ -142,7 +180,7 @@ fn library_item_deep_links_state_and_behavior_hints_default_video_id() {
         state: LibraryItemState {
             last_watched: None,
             time_watched: 999,
-            time_offset: 0,
+            time_offset: 1,
             overall_time_watched: 999,
             times_watched: 999,
             flagged_watched: 1,
@@ -164,6 +202,48 @@ fn library_item_deep_links_state_and_behavior_hints_default_video_id() {
     assert_eq!(
         lidl.meta_details_streams,
         Some("stremio:///detail/movie/tt1254207/video_id".to_string())
+    );
+    assert_eq!(lidl.player, None);
+    assert_eq!(lidl.external_player, None);
+}
+
+#[test]
+fn library_item_deep_links_state_no_time_offset_and_behavior_hints_default_video_id() {
+    let lib_item = LibraryItem {
+        id: "tt1254207".to_string(),
+        name: "Big Buck Bunny".to_string(),
+        r#type: "movie".to_string(),
+        poster: None,
+        poster_shape: PosterShape::Poster,
+        removed: false,
+        temp: true,
+        ctime: None,
+        mtime: Utc::now(),
+        state: LibraryItemState {
+            last_watched: None,
+            time_watched: 999,
+            time_offset: 0,
+            overall_time_watched: 999,
+            times_watched: 999,
+            flagged_watched: 1,
+            duration: 0,
+            video_id: Some("video_id".to_string()),
+            watched: None,
+            last_vid_released: None,
+            no_notif: true,
+        },
+        behavior_hints: MetaItemBehaviorHints {
+            default_video_id: Some("bh_video_id".to_string()),
+            featured_video_id: None,
+            has_scheduled_videos: false,
+            other: Default::default(),
+        },
+    };
+    let lidl = LibraryItemDeepLinks::try_from(&lib_item).unwrap();
+    assert_eq!(lidl.meta_details_videos, None);
+    assert_eq!(
+        lidl.meta_details_streams,
+        Some("stremio:///detail/movie/tt1254207/bh_video_id".to_string())
     );
     assert_eq!(lidl.player, None);
     assert_eq!(lidl.external_player, None);


### PR DESCRIPTION
Current behavior in desktop app for library items is to open the videos page or streams page if library item has continue to watch item. Core now returns streams deeplinks always for lib items which had a video watched at some point, but it was dismissed.