### PR TITLE
Remove debug_assertions derives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    name: Lint, test and check --release
+    name: Lint, test and build
     runs-on: ubuntu-latest
 
     steps:
@@ -31,7 +31,5 @@ jobs:
     - name: Test
       run: cargo test
 
-    # This makes sure that core will be correctly build in release
-    # This will prevent issues caused by `debug_assertions` cfg. attributes
-    - name: Check in --release
-      run: cargo check --release
+    - name: Build
+      run: cargo build

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -29,7 +29,5 @@ jobs:
     - name: Test
       run: cargo test
 
-    # This makes sure that core will be correctly build in release
-    # This will prevent issues caused by `debug_assertions` cfg. attributes
-    - name: Build in --release
-      run: cargo build --release
+    - name: Build
+      run: cargo build

--- a/src/addon_transport/http_transport/legacy/mod.rs
+++ b/src/addon_transport/http_transport/legacy/mod.rs
@@ -23,7 +23,6 @@ const MANIFEST_REQUEST_PARAM: &str =
 // Errors
 //
 #[derive(Debug)]
-
 pub enum LegacyErr {
     JsonRPC(JsonRPCErr),
     UnsupportedResource,
@@ -44,7 +43,6 @@ impl From<LegacyErr> for EnvError {
 // JSON RPC types
 //
 #[derive(Deserialize, Debug)]
-
 pub struct JsonRPCErr {
     message: String,
     #[serde(default)]

--- a/src/addon_transport/http_transport/legacy/mod.rs
+++ b/src/addon_transport/http_transport/legacy/mod.rs
@@ -22,7 +22,8 @@ const MANIFEST_REQUEST_PARAM: &str =
 //
 // Errors
 //
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug)]
+
 pub enum LegacyErr {
     JsonRPC(JsonRPCErr),
     UnsupportedResource,
@@ -42,8 +43,8 @@ impl From<LegacyErr> for EnvError {
 //
 // JSON RPC types
 //
-#[derive(Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Deserialize, Debug)]
+
 pub struct JsonRPCErr {
     message: String,
     #[serde(default)]

--- a/src/deep_links/error_link.rs
+++ b/src/deep_links/error_link.rs
@@ -1,7 +1,6 @@
 use crate::types::query_params_encode;
 
-#[derive(Debug)]
-#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ErrorLink(String);
 
 impl From<anyhow::Error> for ErrorLink {

--- a/src/deep_links/error_link.rs
+++ b/src/deep_links/error_link.rs
@@ -1,6 +1,7 @@
 use crate::types::query_params_encode;
 
-#[cfg_attr(debug_assertions, derive(Debug, PartialEq, Eq))]
+#[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
 pub struct ErrorLink(String);
 
 impl From<anyhow::Error> for ErrorLink {

--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -11,8 +11,8 @@ use crate::types::resource::{MetaItem, MetaItemPreview, Stream, StreamSource, Vi
 use percent_encoding::utf8_percent_encode;
 use serde::Serialize;
 
-#[derive(Default, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug, PartialEq, Eq))]
+#[derive(Default, Serialize, Debug)]
+#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
 pub struct ExternalPlayerLink {
     pub href: Option<String>,
     pub android_tv: Option<String>,
@@ -114,8 +114,8 @@ impl From<&LibraryItem> for LibraryItemDeepLinks {
     }
 }
 
-#[derive(Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug, PartialEq, Eq))]
+#[derive(Serialize, Debug)]
+#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub struct MetaItemDeepLinks {
     pub meta_details_videos: Option<String>,

--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -11,8 +11,7 @@ use crate::types::resource::{MetaItem, MetaItemPreview, Stream, StreamSource, Vi
 use percent_encoding::utf8_percent_encode;
 use serde::Serialize;
 
-#[derive(Default, Serialize, Debug)]
-#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
+#[derive(Default, Serialize, Debug, PartialEq, Eq)]
 pub struct ExternalPlayerLink {
     pub href: Option<String>,
     pub android_tv: Option<String>,
@@ -114,8 +113,7 @@ impl From<&LibraryItem> for LibraryItemDeepLinks {
     }
 }
 
-#[derive(Serialize, Debug)]
-#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
+#[derive(Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetaItemDeepLinks {
     pub meta_details_videos: Option<String>,

--- a/src/models/addon_details.rs
+++ b/src/models/addon_details.rs
@@ -7,8 +7,7 @@ use crate::types::profile::Profile;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Selected {
     pub transport_url: Url,

--- a/src/models/catalog_with_filters.rs
+++ b/src/models/catalog_with_filters.rs
@@ -55,14 +55,14 @@ impl CatalogResourceAdapter for DescriptorPreview {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct Selected {
     pub request: ResourceRequest,
 }
 
-#[derive(PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Clone, Debug))]
+#[derive(PartialEq, Eq, Serialize, Clone, Debug)]
+// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SelectableCatalog {
     pub catalog: String,
@@ -70,24 +70,24 @@ pub struct SelectableCatalog {
     pub request: ResourceRequest,
 }
 
-#[derive(PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Clone, Debug))]
+#[derive(PartialEq, Eq, Serialize, Clone, Debug)]
+// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 pub struct SelectableType {
     pub r#type: String,
     pub selected: bool,
     pub request: ResourceRequest,
 }
 
-#[derive(PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Clone, Debug))]
+#[derive(PartialEq, Eq, Serialize, Clone, Debug)]
+// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 pub struct SelectableExtraOption {
     pub value: Option<String>,
     pub selected: bool,
     pub request: ResourceRequest,
 }
 
-#[derive(PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Clone, Debug))]
+#[derive(PartialEq, Eq, Serialize, Clone, Debug)]
+// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SelectableExtra {
     pub name: String,
@@ -95,14 +95,14 @@ pub struct SelectableExtra {
     pub options: Vec<SelectableExtraOption>,
 }
 
-#[derive(PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Clone, Debug))]
+#[derive(PartialEq, Eq, Serialize, Clone, Debug)]
+// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 pub struct SelectablePage {
     pub request: ResourceRequest,
 }
 
-#[derive(Default, PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Clone, Debug))]
+#[derive(Default, PartialEq, Eq, Serialize, Clone, Debug)]
+// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct Selectable {
     pub types: Vec<SelectableType>,
@@ -120,8 +120,8 @@ pub type CatalogPage<T> = ResourceLoadable<Vec<T>>;
 
 pub type Catalog<T> = Vec<CatalogPage<T>>;
 
-#[derive(Derivative, Serialize)]
-#[cfg_attr(debug_assertions, derive(Clone, Debug))]
+#[derive(Derivative, Serialize, Clone, Debug)]
+// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 #[derivative(Default(bound = ""))]
 pub struct CatalogWithFilters<T> {
     pub selected: Option<Selected>,

--- a/src/models/catalog_with_filters.rs
+++ b/src/models/catalog_with_filters.rs
@@ -56,13 +56,11 @@ impl CatalogResourceAdapter for DescriptorPreview {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct Selected {
     pub request: ResourceRequest,
 }
 
 #[derive(PartialEq, Eq, Serialize, Clone, Debug)]
-// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SelectableCatalog {
     pub catalog: String,
@@ -71,7 +69,6 @@ pub struct SelectableCatalog {
 }
 
 #[derive(PartialEq, Eq, Serialize, Clone, Debug)]
-// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 pub struct SelectableType {
     pub r#type: String,
     pub selected: bool,
@@ -79,7 +76,6 @@ pub struct SelectableType {
 }
 
 #[derive(PartialEq, Eq, Serialize, Clone, Debug)]
-// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 pub struct SelectableExtraOption {
     pub value: Option<String>,
     pub selected: bool,
@@ -87,7 +83,6 @@ pub struct SelectableExtraOption {
 }
 
 #[derive(PartialEq, Eq, Serialize, Clone, Debug)]
-// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SelectableExtra {
     pub name: String,
@@ -96,13 +91,11 @@ pub struct SelectableExtra {
 }
 
 #[derive(PartialEq, Eq, Serialize, Clone, Debug)]
-// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 pub struct SelectablePage {
     pub request: ResourceRequest,
 }
 
 #[derive(Default, PartialEq, Eq, Serialize, Clone, Debug)]
-// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct Selectable {
     pub types: Vec<SelectableType>,
@@ -121,7 +114,6 @@ pub type CatalogPage<T> = ResourceLoadable<Vec<T>>;
 pub type Catalog<T> = Vec<CatalogPage<T>>;
 
 #[derive(Derivative, Serialize, Clone, Debug)]
-// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 #[derivative(Default(bound = ""))]
 pub struct CatalogWithFilters<T> {
     pub selected: Option<Selected>,

--- a/src/models/catalogs_with_extra.rs
+++ b/src/models/catalogs_with_extra.rs
@@ -12,8 +12,8 @@ use futures::FutureExt;
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct Selected {
     pub r#type: Option<String>,
     #[serde(default)]
@@ -24,8 +24,8 @@ pub type CatalogPage<T> = ResourceLoadable<Vec<T>>;
 
 pub type Catalog<T> = Vec<CatalogPage<T>>;
 
-#[derive(Default, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Serialize, Debug)]
+
 pub struct CatalogsWithExtra {
     pub selected: Option<Selected>,
     pub catalogs: Vec<Catalog<MetaItemPreview>>,

--- a/src/models/catalogs_with_extra.rs
+++ b/src/models/catalogs_with_extra.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use std::ops::Range;
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct Selected {
     pub r#type: Option<String>,
     #[serde(default)]
@@ -25,7 +24,6 @@ pub type CatalogPage<T> = ResourceLoadable<Vec<T>>;
 pub type Catalog<T> = Vec<CatalogPage<T>>;
 
 #[derive(Default, Serialize, Debug)]
-
 pub struct CatalogsWithExtra {
     pub selected: Option<Selected>,
     pub catalogs: Vec<Catalog<MetaItemPreview>>,

--- a/src/models/common/descriptor_loadable.rs
+++ b/src/models/common/descriptor_loadable.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 use url::Url;
 
 /// Fetching addons
-#[derive(PartialEq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Clone, Debug))]
+#[derive(PartialEq, Serialize, Clone, Debug)]
+// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 pub struct DescriptorLoadable {
     pub transport_url: Url,
     pub content: Loadable<Descriptor, EnvError>,

--- a/src/models/common/descriptor_loadable.rs
+++ b/src/models/common/descriptor_loadable.rs
@@ -9,7 +9,6 @@ use url::Url;
 
 /// Fetching addons
 #[derive(PartialEq, Serialize, Clone, Debug)]
-// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 pub struct DescriptorLoadable {
     pub transport_url: Url,
     pub content: Loadable<Descriptor, EnvError>,

--- a/src/models/common/loadable.rs
+++ b/src/models/common/loadable.rs
@@ -1,8 +1,7 @@
 use derivative::Derivative;
 use serde::Serialize;
 
-#[derive(Derivative, Clone, PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Derivative, Clone, PartialEq, Eq, Serialize, Debug)]
 #[derivative(Default)]
 #[serde(tag = "type", content = "content")]
 pub enum Loadable<R, E> {

--- a/src/models/common/resource_loadable.rs
+++ b/src/models/common/resource_loadable.rs
@@ -30,7 +30,6 @@ impl fmt::Display for ResourceError {
 
 /// When we want to fetch meta items, streams and catalogues
 #[derive(Clone, PartialEq, Serialize, Debug)]
-
 pub struct ResourceLoadable<T> {
     pub request: ResourceRequest,
     pub content: Option<Loadable<T, ResourceError>>,

--- a/src/models/common/resource_loadable.rs
+++ b/src/models/common/resource_loadable.rs
@@ -8,8 +8,7 @@ use serde::Serialize;
 use std::convert::TryFrom;
 use std::fmt;
 
-#[derive(Clone, PartialEq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Serialize, Debug)]
 #[serde(tag = "type", content = "content")]
 pub enum ResourceError {
     EmptyContent,
@@ -30,8 +29,8 @@ impl fmt::Display for ResourceError {
 }
 
 /// When we want to fetch meta items, streams and catalogues
-#[derive(Clone, PartialEq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Serialize, Debug)]
+
 pub struct ResourceLoadable<T> {
     pub request: ResourceRequest,
     pub content: Option<Loadable<T, ResourceError>>,

--- a/src/models/continue_watching_preview.rs
+++ b/src/models/continue_watching_preview.rs
@@ -7,8 +7,7 @@ use crate::types::library::{LibraryBucket, LibraryItem};
 use lazysort::SortedBy;
 use serde::Serialize;
 
-#[derive(Default, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ContinueWatchingPreview {
     pub library_items: Vec<LibraryItem>,

--- a/src/models/ctx/ctx.rs
+++ b/src/models/ctx/ctx.rs
@@ -18,15 +18,15 @@ use percent_encoding::utf8_percent_encode;
 use serde::Serialize;
 use url::Url;
 
-#[derive(PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Clone, Debug))]
+#[derive(PartialEq, Eq, Serialize, Clone, Debug)]
+// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 pub enum CtxStatus {
     Loading(AuthRequest),
     Ready,
 }
 
-#[derive(Derivative, Serialize)]
-#[cfg_attr(debug_assertions, derive(Clone, Debug))]
+#[derive(Derivative, Serialize, Clone, Debug)]
+// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 #[derivative(Default)]
 pub struct Ctx {
     pub profile: Profile,

--- a/src/models/ctx/ctx.rs
+++ b/src/models/ctx/ctx.rs
@@ -19,14 +19,12 @@ use serde::Serialize;
 use url::Url;
 
 #[derive(PartialEq, Eq, Serialize, Clone, Debug)]
-// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 pub enum CtxStatus {
     Loading(AuthRequest),
     Ready,
 }
 
 #[derive(Derivative, Serialize, Clone, Debug)]
-// #[cfg_attr(debug_assertions, derive(Clone, Debug))]
 #[derivative(Default)]
 pub struct Ctx {
     pub profile: Profile,

--- a/src/models/ctx/error.rs
+++ b/src/models/ctx/error.rs
@@ -4,8 +4,7 @@ use serde::ser::{SerializeStruct, Serializer};
 use serde::Serialize;
 
 // TODO move this to runtime::msg::Error and rename it
-#[derive(Clone, PartialEq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Serialize, Debug)]
 #[serde(tag = "type")]
 pub enum CtxError {
     API(APIError),
@@ -31,8 +30,8 @@ impl From<OtherError> for CtxError {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Debug)]
+
 pub enum OtherError {
     UserNotLoggedIn,
     LibraryItemNotFound,

--- a/src/models/ctx/error.rs
+++ b/src/models/ctx/error.rs
@@ -31,7 +31,6 @@ impl From<OtherError> for CtxError {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-
 pub enum OtherError {
     UserNotLoggedIn,
     LibraryItemNotFound,

--- a/src/models/data_export.rs
+++ b/src/models/data_export.rs
@@ -20,8 +20,7 @@ use super::{
     ctx::{Ctx, CtxError},
 };
 
-#[derive(Serialize, Default, Clone)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Serialize, Default, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DataExport {
     /// This is the Loading result of the User data export request.

--- a/src/models/installed_addons_with_filters.rs
+++ b/src/models/installed_addons_with_filters.rs
@@ -9,14 +9,14 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::iter;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct InstalledAddonsRequest {
     pub r#type: Option<String>,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct Selected {
     pub request: InstalledAddonsRequest,
 }

--- a/src/models/installed_addons_with_filters.rs
+++ b/src/models/installed_addons_with_filters.rs
@@ -10,13 +10,11 @@ use serde::{Deserialize, Serialize};
 use std::iter;
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct InstalledAddonsRequest {
     pub r#type: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct Selected {
     pub request: InstalledAddonsRequest,
 }

--- a/src/models/library_by_type.rs
+++ b/src/models/library_by_type.rs
@@ -13,21 +13,18 @@ use std::marker::PhantomData;
 use strum::IntoEnumIterator;
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct Selected {
     #[serde(default)]
     pub sort: Sort,
 }
 
 #[derive(PartialEq, Eq, Serialize, Debug)]
-
 pub struct SelectableSort {
     pub sort: Sort,
     pub selected: bool,
 }
 
 #[derive(Default, PartialEq, Eq, Serialize, Debug)]
-
 pub struct Selectable {
     pub sorts: Vec<SelectableSort>,
 }

--- a/src/models/library_by_type.rs
+++ b/src/models/library_by_type.rs
@@ -12,22 +12,22 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use strum::IntoEnumIterator;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct Selected {
     #[serde(default)]
     pub sort: Sort,
 }
 
-#[derive(PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(PartialEq, Eq, Serialize, Debug)]
+
 pub struct SelectableSort {
     pub sort: Sort,
     pub selected: bool,
 }
 
-#[derive(Default, PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, PartialEq, Eq, Serialize, Debug)]
+
 pub struct Selectable {
     pub sorts: Vec<SelectableSort>,
 }
@@ -36,8 +36,7 @@ pub type CatalogPage = Vec<LibraryItem>;
 
 pub type Catalog = Vec<CatalogPage>;
 
-#[derive(Derivative, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Derivative, Serialize, Debug)]
 #[derivative(Default(bound = ""))]
 pub struct LibraryByType<F> {
     pub selected: Option<Selected>,

--- a/src/models/library_with_filters.rs
+++ b/src/models/library_with_filters.rs
@@ -19,7 +19,8 @@ pub trait LibraryFilter {
     fn predicate(library_item: &LibraryItem) -> bool;
 }
 
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug)]
+
 pub enum ContinueWatchingFilter {}
 
 impl LibraryFilter for ContinueWatchingFilter {
@@ -28,7 +29,8 @@ impl LibraryFilter for ContinueWatchingFilter {
     }
 }
 
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug)]
+
 pub enum NotRemovedFilter {}
 
 impl LibraryFilter for NotRemovedFilter {
@@ -37,8 +39,7 @@ impl LibraryFilter for NotRemovedFilter {
     }
 }
 
-#[derive(Derivative, Clone, PartialEq, Eq, EnumIter, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Derivative, Clone, PartialEq, Eq, EnumIter, Serialize, Deserialize, Debug)]
 #[derivative(Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Sort {
@@ -48,8 +49,8 @@ pub enum Sort {
     TimesWatched,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct LibraryRequest {
     pub r#type: Option<String>,
     #[serde(default)]
@@ -58,8 +59,8 @@ pub struct LibraryRequest {
     pub page: LibraryRequestPage,
 }
 
-#[derive(Clone, Deref, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deref, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct LibraryRequestPage(pub NonZeroUsize);
 
 impl Default for LibraryRequestPage {
@@ -68,36 +69,36 @@ impl Default for LibraryRequestPage {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct Selected {
     pub request: LibraryRequest,
 }
 
-#[derive(PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(PartialEq, Eq, Serialize, Debug)]
+
 pub struct SelectableType {
     pub r#type: Option<String>,
     pub selected: bool,
     pub request: LibraryRequest,
 }
 
-#[derive(PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(PartialEq, Eq, Serialize, Debug)]
+
 pub struct SelectableSort {
     pub sort: Sort,
     pub selected: bool,
     pub request: LibraryRequest,
 }
 
-#[derive(PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(PartialEq, Eq, Serialize, Debug)]
+
 pub struct SelectablePage {
     pub request: LibraryRequest,
 }
 
-#[derive(Default, PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, PartialEq, Eq, Serialize, Debug)]
+
 pub struct Selectable {
     pub types: Vec<SelectableType>,
     pub sorts: Vec<SelectableSort>,
@@ -105,8 +106,7 @@ pub struct Selectable {
     pub next_page: Option<SelectablePage>,
 }
 
-#[derive(Derivative, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Derivative, Serialize, Debug)]
 #[derivative(Default(bound = ""))]
 pub struct LibraryWithFilters<F> {
     pub selected: Option<Selected>,

--- a/src/models/library_with_filters.rs
+++ b/src/models/library_with_filters.rs
@@ -20,7 +20,6 @@ pub trait LibraryFilter {
 }
 
 #[derive(Debug)]
-
 pub enum ContinueWatchingFilter {}
 
 impl LibraryFilter for ContinueWatchingFilter {
@@ -30,7 +29,6 @@ impl LibraryFilter for ContinueWatchingFilter {
 }
 
 #[derive(Debug)]
-
 pub enum NotRemovedFilter {}
 
 impl LibraryFilter for NotRemovedFilter {
@@ -50,7 +48,6 @@ pub enum Sort {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct LibraryRequest {
     pub r#type: Option<String>,
     #[serde(default)]
@@ -60,7 +57,6 @@ pub struct LibraryRequest {
 }
 
 #[derive(Clone, Deref, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct LibraryRequestPage(pub NonZeroUsize);
 
 impl Default for LibraryRequestPage {
@@ -70,13 +66,11 @@ impl Default for LibraryRequestPage {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct Selected {
     pub request: LibraryRequest,
 }
 
 #[derive(PartialEq, Eq, Serialize, Debug)]
-
 pub struct SelectableType {
     pub r#type: Option<String>,
     pub selected: bool,
@@ -84,7 +78,6 @@ pub struct SelectableType {
 }
 
 #[derive(PartialEq, Eq, Serialize, Debug)]
-
 pub struct SelectableSort {
     pub sort: Sort,
     pub selected: bool,
@@ -92,13 +85,11 @@ pub struct SelectableSort {
 }
 
 #[derive(PartialEq, Eq, Serialize, Debug)]
-
 pub struct SelectablePage {
     pub request: LibraryRequest,
 }
 
 #[derive(Default, PartialEq, Eq, Serialize, Debug)]
-
 pub struct Selectable {
     pub types: Vec<SelectableType>,
     pub sorts: Vec<SelectableSort>,

--- a/src/models/link.rs
+++ b/src/models/link.rs
@@ -13,8 +13,7 @@ use serde::Serialize;
 use std::convert::TryFrom;
 use std::fmt;
 
-#[derive(Clone, PartialEq, From, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, From, Serialize, Debug)]
 #[serde(tag = "type", content = "content")]
 pub enum LinkError {
     API(APIError),
@@ -32,8 +31,7 @@ impl fmt::Display for LinkError {
     }
 }
 
-#[derive(Derivative, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Derivative, Serialize, Debug)]
 #[derivative(Default(bound = ""))]
 #[serde(rename_all = "camelCase")]
 pub struct Link<T> {

--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -16,16 +16,14 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use stremio_watched_bitfield::WatchedBitField;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Selected {
     pub meta_path: ResourcePath,
     pub stream_path: Option<ResourcePath>,
 }
 
-#[derive(Default, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MetaDetails {
     pub selected: Option<Selected>,

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -19,8 +19,7 @@ use stremio_watched_bitfield::WatchedBitField;
 
 use super::common::resource_update_with_vector_content;
 
-#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AnalyticsContext {
     #[serde(rename = "libItemID")]
@@ -43,8 +42,7 @@ pub struct AnalyticsContext {
     pub has_trakt: bool,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Selected {
     pub stream: Stream,
@@ -53,8 +51,7 @@ pub struct Selected {
     pub subtitles_path: Option<ResourcePath>,
 }
 
-#[derive(Default, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Player {
     pub selected: Option<Selected>,

--- a/src/models/streaming_server.rs
+++ b/src/models/streaming_server.rs
@@ -15,8 +15,7 @@ use sha1::{Digest, Sha1};
 use std::iter;
 use url::Url;
 
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
     pub app_path: String,
@@ -31,15 +30,13 @@ pub struct Settings {
     pub bt_min_peers_for_stable: u64,
 }
 
-#[derive(Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Selected {
     pub transport_url: Url,
 }
 
-#[derive(Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct StreamingServer {
     pub selected: Selected,

--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -13,8 +13,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use std::fmt;
 use url::Url;
 
-#[derive(Clone, PartialEq)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Debug)]
 pub enum EnvError {
     Fetch(String),
     AddonTransport(String),

--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -15,8 +15,7 @@ use serde::Deserialize;
 use std::ops::Range;
 use url::Url;
 
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum ActionCtx {
     Authenticate(AuthRequest),
@@ -36,46 +35,40 @@ pub enum ActionCtx {
     SyncLibraryWithAPI,
 }
 
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum ActionCatalogWithFilters {
     LoadNextPage,
 }
 
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum ActionCatalogsWithExtra {
     LoadRange(Range<usize>),
     LoadNextPage(usize),
 }
 
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum ActionLibraryByType {
     LoadNextPage(usize),
 }
 
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum ActionMetaDetails {
     MarkAsWatched(bool),
     MarkVideoAsWatched(String, bool),
 }
 
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum CreateTorrentArgs {
     File(Vec<u8>),
     Magnet(Url),
 }
 
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum ActionStreamingServer {
     Reload,
@@ -83,15 +76,13 @@ pub enum ActionStreamingServer {
     CreateTorrent(CreateTorrentArgs),
 }
 
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum ActionLink {
     ReadData,
 }
 
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum ActionPlayer {
     TimeChanged {
@@ -106,8 +97,7 @@ pub enum ActionPlayer {
     PushToLibrary,
 }
 
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "model", content = "args")]
 pub enum ActionLoad {
     AddonDetails(AddonDetailsSelected),
@@ -127,8 +117,7 @@ pub enum ActionLoad {
 ///
 /// Those messages are meant to be dispatched only by the users of the
 /// `stremio-core` crate and handled by the `stremio-core` crate.
-#[derive(Clone, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum Action {
     Ctx(ActionCtx),

--- a/src/runtime/msg/event.rs
+++ b/src/runtime/msg/event.rs
@@ -9,8 +9,7 @@ use url::Url;
 /// Those messages are meant to be dispatched by the `stremio-core` crate and
 /// handled by the users of the `stremio-core` crate and by the `stremio-core`
 /// crate itself.
-#[derive(Clone, Serialize, Debug)]
-#[cfg_attr(debug_assertions, derive(PartialEq))]
+#[derive(Clone, Serialize, Debug, PartialEq)]
 #[serde(tag = "event", content = "args")]
 pub enum Event {
     PlayerPlaying {

--- a/src/runtime/msg/event.rs
+++ b/src/runtime/msg/event.rs
@@ -9,8 +9,8 @@ use url::Url;
 /// Those messages are meant to be dispatched by the `stremio-core` crate and
 /// handled by the users of the `stremio-core` crate and by the `stremio-core`
 /// crate itself.
-#[derive(Clone, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug, PartialEq))]
+#[derive(Clone, Serialize, Debug)]
+#[cfg_attr(debug_assertions, derive(PartialEq))]
 #[serde(tag = "event", content = "args")]
 pub enum Event {
     PlayerPlaying {

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -10,15 +10,16 @@ use serde::Serialize;
 use std::marker::PhantomData;
 use std::sync::{Arc, LockResult, RwLock, RwLockReadGuard};
 
-#[derive(Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug, PartialEq))]
+#[derive(Serialize, Debug)]
+#[cfg_attr(debug_assertions, derive(PartialEq))]
 #[serde(tag = "name", content = "args")]
 pub enum RuntimeEvent<E: Env, M: Model<E>> {
     NewState(Vec<M::Field>),
     CoreEvent(Event),
 }
 
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug)]
+
 pub struct RuntimeAction<E: Env, M: Model<E>> {
     pub field: Option<M::Field>,
     pub action: Action,

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -10,8 +10,7 @@ use serde::Serialize;
 use std::marker::PhantomData;
 use std::sync::{Arc, LockResult, RwLock, RwLockReadGuard};
 
-#[derive(Serialize, Debug)]
-#[cfg_attr(debug_assertions, derive(PartialEq))]
+#[derive(Serialize, Debug, PartialEq)]
 #[serde(tag = "name", content = "args")]
 pub enum RuntimeEvent<E: Env, M: Model<E>> {
     NewState(Vec<M::Field>),
@@ -19,7 +18,6 @@ pub enum RuntimeEvent<E: Env, M: Model<E>> {
 }
 
 #[derive(Debug)]
-
 pub struct RuntimeAction<E: Env, M: Model<E>> {
     pub field: Option<M::Field>,
     pub action: Action,

--- a/src/types/addon/descriptor.rs
+++ b/src/types/addon/descriptor.rs
@@ -3,8 +3,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 /// Addon descriptor
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Descriptor {
     pub manifest: Manifest,
@@ -13,16 +12,14 @@ pub struct Descriptor {
     pub flags: DescriptorFlags,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DescriptorPreview {
     pub manifest: ManifestPreview,
     pub transport_url: Url,
 }
 
-#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DescriptorFlags {
     #[serde(default)]

--- a/src/types/addon/manifest.rs
+++ b/src/types/addon/manifest.rs
@@ -11,8 +11,7 @@ use std::borrow::Cow;
 use url::Url;
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 #[serde(rename_all = "camelCase")]
@@ -83,8 +82,7 @@ impl Manifest {
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 #[serde(rename_all = "camelCase")]
@@ -103,8 +101,7 @@ pub struct ManifestPreview {
     pub types: Vec<String>,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum ManifestResource {
     Short(String),
@@ -126,8 +123,7 @@ impl ManifestResource {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ManifestCatalog {
     pub id: String,
@@ -182,7 +178,7 @@ impl UniqueVecAdapter for ManifestCatalogUniqueVecAdapter {
 #[serde_as]
 #[derive(Derivative, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[derivative(Default)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug)]
 #[serde(untagged)]
 pub enum ManifestExtra {
     #[derivative(Default)]
@@ -223,8 +219,7 @@ impl ManifestExtra {
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtraProp {
     pub name: String,
@@ -271,8 +266,8 @@ impl<'de> DeserializeAs<'de, ExtraProp> for ExtraPropValid {
     }
 }
 
-#[derive(Clone, Deref, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Deref, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct OptionsLimit(pub usize);
 
 impl Default for OptionsLimit {
@@ -281,8 +276,7 @@ impl Default for OptionsLimit {
     }
 }
 
-#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ManifestBehaviorHints {
     #[serde(default)]

--- a/src/types/addon/manifest.rs
+++ b/src/types/addon/manifest.rs
@@ -176,9 +176,8 @@ impl UniqueVecAdapter for ManifestCatalogUniqueVecAdapter {
 }
 
 #[serde_as]
-#[derive(Derivative, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Derivative, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[derivative(Default)]
-#[derive(Debug)]
 #[serde(untagged)]
 pub enum ManifestExtra {
     #[derivative(Default)]
@@ -267,7 +266,6 @@ impl<'de> DeserializeAs<'de, ExtraProp> for ExtraPropValid {
 }
 
 #[derive(Clone, Deref, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct OptionsLimit(pub usize);
 
 impl Default for OptionsLimit {

--- a/src/types/addon/request.rs
+++ b/src/types/addon/request.rs
@@ -3,8 +3,7 @@ use derive_more::{From, Into};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-#[derive(Clone, From, Into, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, From, Into, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(from = "(String, String)", into = "(String, String)")]
 pub struct ExtraValue {
     pub name: String,
@@ -51,8 +50,7 @@ impl ExtraExt for Vec<ExtraValue> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Default))]
 pub struct ResourcePath {
     pub resource: String,
@@ -93,8 +91,7 @@ impl ResourcePath {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct ResourceRequest {
     pub base: Url,
     pub path: ResourcePath,
@@ -110,8 +107,8 @@ impl ResourceRequest {
     }
 }
 
-#[derive(Clone)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Debug)]
+
 pub enum AggrRequest<'a> {
     AllCatalogs {
         extra: &'a Vec<ExtraValue>,

--- a/src/types/addon/request.rs
+++ b/src/types/addon/request.rs
@@ -108,7 +108,6 @@ impl ResourceRequest {
 }
 
 #[derive(Clone, Debug)]
-
 pub enum AggrRequest<'a> {
     AllCatalogs {
         extra: &'a Vec<ExtraValue>,

--- a/src/types/addon/response.rs
+++ b/src/types/addon/response.rs
@@ -4,8 +4,7 @@ use derive_more::TryInto;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, TryInto, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, TryInto, Serialize, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(untagged)]
 pub enum ResourceResponse {

--- a/src/types/api/request.rs
+++ b/src/types/api/request.rs
@@ -16,8 +16,7 @@ pub trait FetchRequestParams<T> {
     fn body(self) -> T;
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Debug)]
 #[serde(tag = "type")]
 pub enum APIRequest {
     Auth(AuthRequest),
@@ -85,8 +84,7 @@ impl FetchRequestParams<APIRequest> for APIRequest {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 #[serde(tag = "type")]
@@ -108,8 +106,7 @@ pub enum AuthRequest {
     },
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 #[serde(tag = "type")]
@@ -140,8 +137,7 @@ impl FetchRequestParams<()> for LinkRequest {
     fn body(self) {}
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DatastoreRequest {
     pub auth_key: AuthKey,
@@ -172,8 +168,7 @@ impl FetchRequestParams<DatastoreRequest> for DatastoreRequest {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 #[serde(untagged)]

--- a/src/types/api/response.rs
+++ b/src/types/api/response.rs
@@ -6,16 +6,14 @@ use chrono::{DateTime, Utc};
 use derive_more::TryInto;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum APIResult<T> {
     Err { error: APIError },
     Ok { result: T },
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Default))]
 pub struct APIError {
     pub message: String,
@@ -42,8 +40,8 @@ pub struct DataExportResponse {
     pub export_id: String,
 }
 
-#[derive(PartialEq, Eq, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(PartialEq, Eq, Deserialize, Debug)]
+
 pub struct LibraryItemModified(
     pub String,
     #[serde(with = "ts_milliseconds")] pub DateTime<Utc>,
@@ -54,23 +52,21 @@ pub struct SuccessResponse {
     pub success: True,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct LinkCodeResponse {
     pub code: String,
     pub link: String,
     pub qrcode: String,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkAuthKey {
     pub auth_key: String,
 }
 
-#[derive(Clone, TryInto, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, TryInto, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(untagged)]
 pub enum LinkDataResponse {

--- a/src/types/api/response.rs
+++ b/src/types/api/response.rs
@@ -41,7 +41,6 @@ pub struct DataExportResponse {
 }
 
 #[derive(PartialEq, Eq, Deserialize, Debug)]
-
 pub struct LibraryItemModified(
     pub String,
     #[serde(with = "ts_milliseconds")] pub DateTime<Utc>,
@@ -53,7 +52,6 @@ pub struct SuccessResponse {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct LinkCodeResponse {
     pub code: String,
     pub link: String,

--- a/src/types/library/library_bucket.rs
+++ b/src/types/library/library_bucket.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::collections::{HashMap, HashSet};
 
-#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct LibraryBucket {
     pub uid: UID,
     pub items: HashMap<String, LibraryItem>,

--- a/src/types/library/library_bucket.rs
+++ b/src/types/library/library_bucket.rs
@@ -7,7 +7,6 @@ use std::cmp;
 use std::collections::{HashMap, HashSet};
 
 #[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct LibraryBucket {
     pub uid: UID,
     pub items: HashMap<String, LibraryItem>,

--- a/src/types/library/library_item.rs
+++ b/src/types/library/library_item.rs
@@ -11,7 +11,8 @@ use url::Url;
 #[serde_as]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug)]
+
 pub struct LibraryItem {
     #[serde(rename = "_id")]
     pub id: String,
@@ -24,9 +25,11 @@ pub struct LibraryItem {
     pub poster_shape: PosterShape,
     pub removed: bool,
     pub temp: bool,
+    /// Creation time
     #[serde(default, rename = "_ctime")]
     #[serde_as(deserialize_as = "DefaultOnNull<NoneAsEmptyString>")]
     pub ctime: Option<DateTime<Utc>>,
+    /// Modification time
     #[serde(rename = "_mtime")]
     pub mtime: DateTime<Utc>,
     pub state: LibraryItemState,
@@ -89,7 +92,8 @@ impl From<(&MetaItemPreview, &LibraryItem)> for LibraryItem {
 #[serde_as]
 #[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug)]
+
 pub struct LibraryItemState {
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull<NoneAsEmptyString>")]
@@ -97,13 +101,23 @@ pub struct LibraryItemState {
     pub time_watched: u64,
     pub time_offset: u64,
     pub overall_time_watched: u64,
+    /// Shows how many times this item has been watched.
+    ///
+    /// Incremented once for each video watched
+    /// or in the case of no videos - every time
     pub times_watched: u32,
     // @TODO: consider bool that can be deserialized from an integer
     pub flagged_watched: u32,
     pub duration: u64,
+    /// The last video watched.
+    ///
+    /// - For meta's without videos it's either `behavior_hints.default_video_id` (if present) or the `meta.id`
+    /// - For meta's with video - the played video.
     #[serde(default, rename = "video_id")]
     #[serde_as(deserialize_as = "DefaultOnNull<NoneAsEmptyString>")]
     pub video_id: Option<String>,
+    /// Field tracking watched videos.
+    /// For [`LibraryItem`]s without videos, this field should [`None`].
     // @TODO bitfield, special type
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull<NoneAsEmptyString>")]

--- a/src/types/library/library_item.rs
+++ b/src/types/library/library_item.rs
@@ -9,10 +9,8 @@ use stremio_watched_bitfield::WatchedBitField;
 use url::Url;
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Debug)]
-
 pub struct LibraryItem {
     #[serde(rename = "_id")]
     pub id: String,
@@ -90,10 +88,8 @@ impl From<(&MetaItemPreview, &LibraryItem)> for LibraryItem {
 }
 
 #[serde_as]
-#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Debug)]
-
 pub struct LibraryItemState {
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull<NoneAsEmptyString>")]
@@ -122,10 +118,11 @@ pub struct LibraryItemState {
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull<NoneAsEmptyString>")]
     pub watched: Option<String>,
-    // release date of last observed video
+    /// Release date of last observed video
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull<NoneAsEmptyString>")]
     pub last_vid_released: Option<DateTime<Utc>>,
+    /// Weather or not to receive notification for the given [`LibraryItem`].
     pub no_notif: bool,
 }
 

--- a/src/types/profile/auth.rs
+++ b/src/types/profile/auth.rs
@@ -1,13 +1,11 @@
 use crate::types::profile::User;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Default))]
 pub struct AuthKey(pub String);
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Default))]
 pub struct Auth {
     pub key: AuthKey,

--- a/src/types/profile/profile.rs
+++ b/src/types/profile/profile.rs
@@ -10,8 +10,8 @@ use url::Url;
 pub type UID = Option<String>;
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct Profile {
     pub auth: Option<Auth>,
     #[serde_as(deserialize_as = "UniqueVec<Vec<_>, DescriptorUniqueVecAdapter>")]

--- a/src/types/profile/profile.rs
+++ b/src/types/profile/profile.rs
@@ -11,7 +11,6 @@ pub type UID = Option<String>;
 
 #[serde_as]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct Profile {
     pub auth: Option<Auth>,
     #[serde_as(deserialize_as = "UniqueVec<Vec<_>, DescriptorUniqueVecAdapter>")]

--- a/src/types/profile/settings.rs
+++ b/src/types/profile/settings.rs
@@ -3,10 +3,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Debug)]
-
 pub struct Settings {
     pub interface_language: String,
     pub streaming_server_url: Url,

--- a/src/types/profile/settings.rs
+++ b/src/types/profile/settings.rs
@@ -5,7 +5,8 @@ use url::Url;
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug)]
+
 pub struct Settings {
     pub interface_language: String,
     pub streaming_server_url: Url,

--- a/src/types/profile/user.rs
+++ b/src/types/profile/user.rs
@@ -32,9 +32,8 @@ pub struct GDPRConsent {
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 pub struct User {

--- a/src/types/profile/user.rs
+++ b/src/types/profile/user.rs
@@ -8,8 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnError, DefaultOnNull, DurationSeconds, NoneAsEmptyString};
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 pub struct TraktInfo {
@@ -23,8 +22,7 @@ pub struct TraktInfo {
     pub access_token: String,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Default))]
 pub struct GDPRConsent {
     pub tos: bool,
@@ -36,7 +34,7 @@ pub struct GDPRConsent {
 #[serde_as]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 pub struct User {

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -298,7 +298,6 @@ impl SortedVecAdapter for VideoSortedVecAdapter {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-
 pub struct Link {
     pub name: String,
     pub category: String,

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -21,8 +21,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use url::Url;
 
-#[derive(Clone, PartialEq, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Deserialize, Debug)]
 #[cfg_attr(test, derive(Default))]
 struct Trailer {
     source: String,
@@ -46,8 +45,7 @@ impl<'de> DeserializeAs<'de, Trailer> for Stream {
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Deserialize, Debug)]
 #[cfg_attr(test, derive(Default))]
 #[serde(rename_all = "camelCase")]
 struct MetaItemPreviewLegacy {
@@ -91,8 +89,7 @@ struct MetaItemPreviewLegacy {
     behavior_hints: MetaItemBehaviorHints,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Default))]
 #[serde(rename_all = "camelCase", try_from = "MetaItemPreviewLegacy")]
 pub struct MetaItemPreview {
@@ -188,8 +185,7 @@ impl From<MetaItemPreviewLegacy> for MetaItemPreview {
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Default))]
 #[serde(rename_all = "camelCase")]
 pub struct MetaItem {
@@ -202,8 +198,7 @@ pub struct MetaItem {
     pub videos: Vec<Video>,
 }
 
-#[derive(Derivative, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Derivative, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[derivative(Default)]
 #[serde(rename_all = "camelCase")]
 pub enum PosterShape {
@@ -214,8 +209,7 @@ pub enum PosterShape {
     Poster,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Default))]
 pub struct SeriesInfo {
     pub season: u32,
@@ -223,8 +217,7 @@ pub struct SeriesInfo {
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Video {
     pub id: String,
@@ -304,16 +297,15 @@ impl SortedVecAdapter for VideoSortedVecAdapter {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+
 pub struct Link {
     pub name: String,
     pub category: String,
     pub url: Url,
 }
 
-#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MetaItemBehaviorHints {
     #[serde(default)]

--- a/src/types/resource/stream.rs
+++ b/src/types/resource/stream.rs
@@ -14,8 +14,7 @@ use std::io::Write;
 use stremio_serde_hex::{SerHex, Strict};
 use url::Url;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Stream {
     #[serde(flatten)]
@@ -96,8 +95,7 @@ impl Stream {
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 #[serde(untagged)]
@@ -171,8 +169,7 @@ where
     ))
 }
 
-#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct StreamProxyHeaders {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -181,8 +178,7 @@ pub struct StreamProxyHeaders {
     pub response: HashMap<String, String>,
 }
 
-#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct StreamBehaviorHints {
     #[serde(default, skip_serializing_if = "is_default_value")]

--- a/src/types/resource/subtitles.rs
+++ b/src/types/resource/subtitles.rs
@@ -3,8 +3,7 @@ use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 pub struct Subtitles {

--- a/src/types/true.rs
+++ b/src/types/true.rs
@@ -1,8 +1,7 @@
 use serde::de::Unexpected;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(test, derive(Default))]
 pub struct True;
 

--- a/src/unit_tests/catalog_with_filters/load_action.rs
+++ b/src/unit_tests/catalog_with_filters/load_action.rs
@@ -18,7 +18,7 @@ use url::Url;
 
 #[test]
 fn default_catalog() {
-    #[derive(Model, Default, Debug, Clone)]
+    #[derive(Model, Default, Clone, Debug)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -111,7 +111,7 @@ fn default_catalog() {
 
 #[test]
 fn search_catalog() {
-    #[derive(Model, Default, Debug, Clone)]
+    #[derive(Model, Default, Clone, Debug)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/data_export.rs
+++ b/src/unit_tests/data_export.rs
@@ -15,7 +15,7 @@ use std::any::Any;
 use std::sync::{Arc, RwLock};
 use stremio_derive::Model;
 
-#[derive(Model, Default, Debug, Clone)]
+#[derive(Model, Default, Clone, Debug)]
 #[model(TestEnv)]
 struct TestModel {
     ctx: Ctx,

--- a/src/unit_tests/env.rs
+++ b/src/unit_tests/env.rs
@@ -28,7 +28,7 @@ lazy_static! {
 pub type FetchHandler =
     Box<dyn Fn(Request) -> TryEnvFuture<Box<dyn Any + Send>> + Send + Sync + 'static>;
 
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct Request {
     pub url: String,
     pub method: String,

--- a/stremio-analytics/src/lib.rs
+++ b/stremio-analytics/src/lib.rs
@@ -17,7 +17,6 @@ use stremio_core::types::profile::AuthKey;
 use stremio_core::types::True;
 
 #[derive(Clone, PartialEq, Serialize, Debug)]
-
 struct Event {
     #[serde(flatten)]
     data: serde_json::Value,
@@ -32,7 +31,6 @@ struct Event {
 }
 
 #[derive(Clone, PartialEq, Debug)]
-
 struct EventsBatch {
     auth_key: AuthKey,
     events: Vec<Event>,
@@ -156,6 +154,7 @@ fn send_events_batch_to_api<E: Env>(
         })
         .boxed_env();
     };
+
     fetch_api::<E, _, _, _>(&APIRequest::Events {
         auth_key: batch.auth_key.to_owned(),
         events: batch

--- a/stremio-analytics/src/lib.rs
+++ b/stremio-analytics/src/lib.rs
@@ -16,8 +16,8 @@ use stremio_core::types::profile::AuthKey;
 #[cfg(debug_assertions)]
 use stremio_core::types::True;
 
-#[derive(Clone, PartialEq, Serialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Serialize, Debug)]
+
 struct Event {
     #[serde(flatten)]
     data: serde_json::Value,
@@ -31,8 +31,8 @@ struct Event {
     context: serde_json::Value,
 }
 
-#[derive(Clone, PartialEq)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, PartialEq, Debug)]
+
 struct EventsBatch {
     auth_key: AuthKey,
     events: Vec<Event>,

--- a/stremio-derive/src/lib.rs
+++ b/stremio-derive/src/lib.rs
@@ -111,28 +111,26 @@ pub fn model_derive(input: TokenStream) -> TokenStream {
                 }))
                 .collect::<Vec<_>>();
             TokenStream::from(quote! {
-                            #[derive(serde::Serialize, serde::Deserialize)]
-                            #[derive(Debug)]
-            #[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
-                            #[serde(rename_all = "snake_case")]
-                            pub enum #field_enum_ident {
-                                #(#field_enum_variant_idents),*
-                            }
+                #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+                #[serde(rename_all = "snake_case")]
+                pub enum #field_enum_ident {
+                    #(#field_enum_variant_idents),*
+                }
 
-                            impl #core_ident::runtime::Model<#env_ident> for #struct_ident {
-                                type Field = #field_enum_ident;
+                impl #core_ident::runtime::Model<#env_ident> for #struct_ident {
+                    type Field = #field_enum_ident;
 
-                                fn update(&mut self, msg: &#core_ident::runtime::msg::Msg) -> (Vec<#core_ident::runtime::Effect>, Vec<Self::Field>) {
-                                    #(#field_updates_chain)*
-                                }
+                    fn update(&mut self, msg: &#core_ident::runtime::msg::Msg) -> (Vec<#core_ident::runtime::Effect>, Vec<Self::Field>) {
+                        #(#field_updates_chain)*
+                    }
 
-                                fn update_field(&mut self, msg: &#core_ident::runtime::msg::Msg, field: &Self::Field) -> (Vec<#core_ident::runtime::Effect>, Vec<Self::Field>) {
-                                    match field {
-                                        #(#field_update_match_arms),*
-                                    }
-                                }
-                            }
-                        })
+                    fn update_field(&mut self, msg: &#core_ident::runtime::msg::Msg, field: &Self::Field) -> (Vec<#core_ident::runtime::Effect>, Vec<Self::Field>) {
+                        match field {
+                            #(#field_update_match_arms),*
+                        }
+                    }
+                }
+            })
         }
         _ => panic!("#[derive(Model)] is only defined for structs with named fields"),
     }

--- a/stremio-derive/src/lib.rs
+++ b/stremio-derive/src/lib.rs
@@ -111,27 +111,28 @@ pub fn model_derive(input: TokenStream) -> TokenStream {
                 }))
                 .collect::<Vec<_>>();
             TokenStream::from(quote! {
-                #[derive(serde::Serialize, serde::Deserialize)]
-                #[cfg_attr(debug_assertions, derive(Debug, PartialEq, Eq))]
-                #[serde(rename_all = "snake_case")]
-                pub enum #field_enum_ident {
-                    #(#field_enum_variant_idents),*
-                }
+                            #[derive(serde::Serialize, serde::Deserialize)]
+                            #[derive(Debug)]
+            #[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
+                            #[serde(rename_all = "snake_case")]
+                            pub enum #field_enum_ident {
+                                #(#field_enum_variant_idents),*
+                            }
 
-                impl #core_ident::runtime::Model<#env_ident> for #struct_ident {
-                    type Field = #field_enum_ident;
+                            impl #core_ident::runtime::Model<#env_ident> for #struct_ident {
+                                type Field = #field_enum_ident;
 
-                    fn update(&mut self, msg: &#core_ident::runtime::msg::Msg) -> (Vec<#core_ident::runtime::Effect>, Vec<Self::Field>) {
-                        #(#field_updates_chain)*
-                    }
+                                fn update(&mut self, msg: &#core_ident::runtime::msg::Msg) -> (Vec<#core_ident::runtime::Effect>, Vec<Self::Field>) {
+                                    #(#field_updates_chain)*
+                                }
 
-                    fn update_field(&mut self, msg: &#core_ident::runtime::msg::Msg, field: &Self::Field) -> (Vec<#core_ident::runtime::Effect>, Vec<Self::Field>) {
-                        match field {
-                            #(#field_update_match_arms),*
-                        }
-                    }
-                }
-            })
+                                fn update_field(&mut self, msg: &#core_ident::runtime::msg::Msg, field: &Self::Field) -> (Vec<#core_ident::runtime::Effect>, Vec<Self::Field>) {
+                                    match field {
+                                        #(#field_update_match_arms),*
+                                    }
+                                }
+                            }
+                        })
         }
         _ => panic!("#[derive(Model)] is only defined for structs with named fields"),
     }

--- a/stremio-watched-bitfield/src/bitfield8.rs
+++ b/stremio-watched-bitfield/src/bitfield8.rs
@@ -6,7 +6,7 @@ use flate2::Compression;
 use std::convert::TryFrom;
 use std::io::{Read, Write};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BitField8 {
     pub length: usize,
     values: Vec<u8>,

--- a/stremio-watched-bitfield/src/watched_bitfield.rs
+++ b/stremio-watched-bitfield/src/watched_bitfield.rs
@@ -3,7 +3,7 @@ use crate::error::Error;
 use std::convert::TryFrom;
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WatchedBitField {
     bitfield: BitField8,
     video_ids: Vec<String>,


### PR DESCRIPTION
I ran a few comparisons on the size of wasm builds with and without these `cfg_attr`ibutes to see if they make a big change.
They don't so we've decided to remove then and remove the need for building `core` with `--release` in the CI.


# Core:

Moving Debug derive out of `debug_assertions` builds:

`#[cfg_attr(debug_assertions, derive(Debug, ..))]`

```
$ du -d 1 --bytes 1_wasm_with_no_debug/*
883219	1_wasm_with_no_debug/stremio_core_validator_bg.wasm
7348	1_wasm_with_no_debug/stremio_core_validator.js
```

By including Debug in release - `#[derive(Debug, ..)]`:

```
$ du -d 1 --bytes 4_wasm_with_derive_debug_3/*
883235	4_wasm_with_dervie_debug_3/stremio_core_validator_bg.wasm
7348	4_wasm_with_dervie_debug_3/stremio_core_validator.js
```

For the last comparison, I removing all `debug_assertions` derives, e.g.:

`#[cfg_attr(debug_assertions, derive(PartialEq, ..))]`

```
du -d 1 --bytes 5_wasm_with_all_derives/*
883235	5_wasm_with_all_derives/stremio_core_validator_bg.wasm
7348	5_wasm_with_all_derives/stremio_core_validator.js
```

The difference in the size is 16 bytes.


# Core-web:

No derives

```
$ du -d 1 --bytes 1_no_derive/*
2662721	1_no_derive/stremio_core_web_bg.wasm
39897	1_no_derive/stremio_core_web.js
```

With all derives:

```
$ du -d 1 --bytes 2_with_derive/*
2665722	2_with_derive/stremio_core_web_bg.wasm
39897	2_with_derive/stremio_core_web.js
```

The difference in the size is 1 byte.

# Conclusion

I would suggest to remove this cfg_attr and later, in CI, we have no reason to build in `--release` in the core repo which will drastically improve build times again.