### PR TITLE
feat: Conditional types for futures and traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 
 # Adds `Send` marker trait to the `Env` trait methods and `EnvFuture`.
 # It's required for environments that do not support `Send`.
-# If enabled for `wasm` it will do nothing since `wasm` does not support Send!
+# If enabled for `wasm` it will cause a compile error!
 # see https://github.com/rustwasm/wasm-bindgen/issues/2833
 env-future-send = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,14 @@ members = [
 doctest = false
 
 [features]
+# TODO: env-future-send should be enabled by default
+# but our `TestEnv` for `unit_tests` uses a MutexGuard which is not Send.
+# default = ["env-future-send"]
+
+# Adds `Send` marker trait to the `Env` trait methods and `EnvFuture`.
+# It's required for environments that do not support `Send`.
+# If enabled for `wasm` it will do nothing since `wasm` does not support Send!
+# see https://github.com/rustwasm/wasm-bindgen/issues/2833
 env-future-send = []
 
 [dependencies]

--- a/src/addon_transport/unsupported_transport.rs
+++ b/src/addon_transport/unsupported_transport.rs
@@ -1,5 +1,5 @@
 use crate::addon_transport::AddonTransport;
-use crate::runtime::{EnvError, EnvFutureExt, TryEnvFuture};
+use crate::runtime::{ConditionalSend, EnvError, EnvFutureExt, TryEnvFuture};
 use crate::types::addon::{Manifest, ResourcePath, ResourceResponse};
 use futures::future;
 use url::Url;
@@ -12,12 +12,7 @@ impl UnsupportedTransport {
     pub fn new(transport_url: Url) -> Self {
         UnsupportedTransport { transport_url }
     }
-    fn result<
-        #[cfg(not(feature = "env-future-send"))] T: Sized + 'static,
-        #[cfg(feature = "env-future-send")] T: Sized + Send + 'static,
-    >(
-        &self,
-    ) -> TryEnvFuture<T> {
+    fn result<T: Sized + ConditionalSend + 'static>(&self) -> TryEnvFuture<T> {
         future::err(EnvError::AddonTransport(format!(
             "Unsupported addon transport: {}",
             self.transport_url.scheme()

--- a/src/runtime/effects.rs
+++ b/src/runtime/effects.rs
@@ -1,11 +1,9 @@
 use crate::runtime::msg::Msg;
 use derive_more::{From, IntoIterator};
 
-#[cfg(not(feature = "env-future-send"))]
-type Future = futures::future::LocalBoxFuture<'static, Msg>;
+use super::EnvFuture;
 
-#[cfg(feature = "env-future-send")]
-type Future = futures::future::BoxFuture<'static, Msg>;
+type Future = EnvFuture<'static, Msg>;
 
 pub enum EffectFuture {
     Concurrent(Future),

--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -86,7 +86,7 @@ impl From<serde_json::Error> for EnvError {
     }
 }
 
-#[cfg(any(not(feature = "env-future-send"), target_family = "wasm"))]
+#[cfg(not(feature = "env-future-send"))]
 /// Only for wasm or when `env-future-send` is not enabled
 mod conditional_types {
     use futures::{future::LocalBoxFuture, Future, FutureExt};
@@ -107,8 +107,9 @@ mod conditional_types {
     }
 }
 
-#[cfg(all(feature = "env-future-send", not(target_family = "wasm")))]
+#[cfg(feature = "env-future-send")]
 /// Enabled with the feature `env-future-send` but it requires a non-wasm target!
+/// It will cause a compile-time error!
 mod conditional_types {
     use futures::{future::BoxFuture, Future, FutureExt};
 

--- a/src/types/api/fetch_api.rs
+++ b/src/types/api/fetch_api.rs
@@ -1,15 +1,16 @@
-use crate::runtime::{Env, TryEnvFuture};
-use crate::types::api::{APIResult, FetchRequestParams};
+use crate::{
+    runtime::{ConditionalSend, Env, TryEnvFuture},
+    types::api::{APIResult, FetchRequestParams},
+};
+
 use http::Request;
 use serde::{Deserialize, Serialize};
 
 pub fn fetch_api<
     E: Env,
-    #[cfg(not(feature = "env-future-send"))] BODY: Serialize + 'static,
-    #[cfg(feature = "env-future-send")] BODY: Serialize + Send + 'static,
+    BODY: Serialize + ConditionalSend + 'static,
     REQ: FetchRequestParams<BODY> + Clone + Serialize,
-    #[cfg(not(feature = "env-future-send"))] RESP: for<'de> Deserialize<'de> + 'static,
-    #[cfg(feature = "env-future-send")] RESP: for<'de> Deserialize<'de> + Send + 'static,
+    RESP: for<'de> Deserialize<'de> + ConditionalSend + 'static,
 >(
     api_request: &REQ,
 ) -> TryEnvFuture<APIResult<RESP>> {

--- a/src/unit_tests/env.rs
+++ b/src/unit_tests/env.rs
@@ -1,8 +1,6 @@
 use crate::models::ctx::Ctx;
 use crate::models::streaming_server::StreamingServer;
-use crate::runtime::{
-    ConditionalSend, Env, EnvFuture, EnvFutureExt, Model, Runtime, RuntimeEvent, TryEnvFuture,
-};
+use crate::runtime::{Env, EnvFuture, EnvFutureExt, Model, Runtime, RuntimeEvent, TryEnvFuture};
 use chrono::{DateTime, Utc};
 use enclose::enclose;
 use futures::channel::mpsc::Receiver;
@@ -106,10 +104,7 @@ impl TestEnv {
 }
 
 impl Env for TestEnv {
-    fn fetch<
-        IN: Serialize + ConditionalSend + 'static,
-        OUT: for<'de> Deserialize<'de> + ConditionalSend + 'static,
-    >(
+    fn fetch<IN: Serialize + 'static, OUT: for<'de> Deserialize<'de> + 'static>(
         request: http::Request<IN>,
     ) -> TryEnvFuture<OUT> {
         let request = Request::from(request);
@@ -122,9 +117,7 @@ impl Env for TestEnv {
             })
             .boxed_env()
     }
-    fn get_storage<T: for<'de> Deserialize<'de> + ConditionalSend + 'static>(
-        key: &str,
-    ) -> TryEnvFuture<Option<T>> {
+    fn get_storage<T: for<'de> Deserialize<'de> + 'static>(key: &str) -> TryEnvFuture<Option<T>> {
         future::ok(
             STORAGE
                 .read()
@@ -142,10 +135,10 @@ impl Env for TestEnv {
         };
         future::ok(()).boxed_env()
     }
-    fn exec_concurrent<F: Future<Output = ()> + ConditionalSend + 'static>(future: F) {
+    fn exec_concurrent<F: Future<Output = ()> + 'static>(future: F) {
         tokio_current_thread::spawn(future);
     }
-    fn exec_sequential<F: Future<Output = ()> + ConditionalSend + 'static>(future: F) {
+    fn exec_sequential<F: Future<Output = ()> + 'static>(future: F) {
         tokio_current_thread::spawn(future);
     }
     fn now() -> DateTime<Utc> {


### PR DESCRIPTION
Conditional `Send` is enabled by:
- feature `env-future-send` (not applicable to wasm)
- ~target_family **!=** wasm~ **reverted!** will cause compile-time error if Send is enabled for wasm!

### WASM futures should not be Send - https://github.com/rustwasm/wasm-bindgen/issues/2833

# TODO (before merging)
Check `core-*` builds:
- [x] core-web
- [x] core-kotlin (created a branch to test the build using `release.yaml` https://github.com/Stremio/stremio-core-kotlin/actions/runs/3846096023/jobs/6551003529)
- [x] core-validator