### PR TITLE
Docs ci workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+# keep the workflow only for manual deployment because of Github monthly CI quota
+on: workflow_dispatch
+
+name: Deploy docs
+
+jobs:
+  deploy-docs:
+    name: Deploy docs on gh-pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          # Use nightly to build the docs with `--cfg docsrs`
+          toolchain: nightly
+          profile: minimal
+          components: rust-docs
+      - name: Build docs
+        # Building locally:
+        # for `--enable-index-page` it is required to pass `-Z unstable-options` to rustdocs
+        run: RUSTDOCFLAGS="--cfg docsrs -Z unstable-options --enable-index-page" cargo +nightly doc --all-features --no-deps --workspace
+      - name: Prepare /docs
+        run: |
+          rm -rf ./docs
+          mv target/doc ./docs
+      - name: Deploy gh-pages
+        # if: github.ref == 'refs/heads/aip-61-adex-v5'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,5 @@
 # keep the workflow only for manual deployment because of Github monthly CI quota
 on:
-  push:
-    branches:
-      - docs-ci-workflow
   workflow_dispatch:
 
 name: Deploy docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,9 @@
 # keep the workflow only for manual deployment because of Github monthly CI quota
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - docs-ci-workflow
+  workflow_dispatch:
 
 name: Deploy docs
 
@@ -26,7 +30,6 @@ jobs:
           rm -rf ./docs
           mv target/doc ./docs
       - name: Deploy gh-pages
-        # if: github.ref == 'refs/heads/aip-61-adex-v5'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Builds docs for all crates present in `stremio-core` and deploys them on Github pages.

For now we will only allow it for manual deployment.

# TODO
Check whether reaching CI quote in GH they also stop the CI builds for our public repos?

**NOTE:** GH gives free minutes to all public repos, so I'm wondering since core is public it should not contribute to the quota. 