### PR TITLE
handle player push to api behaviour internally

### DIFF
--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -225,6 +225,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                 };
                 let switch_to_next_video_effects =
                     switch_to_next_video(&mut self.library_item, &self.next_video);
+                let push_to_api_effect = push_to_api(&self.library_item);
                 let selected_effects = eq_update(&mut self.selected, None);
                 let meta_item_effects = eq_update(&mut self.meta_item, None);
                 let subtitles_effects = eq_update(&mut self.subtitles, vec![]);
@@ -233,13 +234,13 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                 let series_info_effects = eq_update(&mut self.series_info, None);
                 let library_item_effects = eq_update(&mut self.library_item, None);
                 let watched_effects = eq_update(&mut self.watched, None);
-                let push_to_api_effect = push_to_api(&self.library_item);
                 self.analytics_context = None;
                 self.load_time = None;
                 self.loaded = false;
                 self.ended = false;
                 self.paused = None;
                 switch_to_next_video_effects
+                    .join(push_to_api_effect)
                     .join(selected_effects)
                     .join(meta_item_effects)
                     .join(subtitles_effects)
@@ -249,7 +250,6 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     .join(library_item_effects)
                     .join(watched_effects)
                     .join(ended_effects)
-                    .join(push_to_api_effect)
             }
             Msg::Action(Action::Player(ActionPlayer::TimeChanged {
                 time,

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -237,7 +237,13 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                 };
                 let switch_to_next_video_effects =
                     switch_to_next_video(&mut self.library_item, &self.next_video);
-                let push_to_library_effects = update_library_item(&self.library_item);
+                let push_to_library_effects = match &self.library_item {
+                    Some(library_item) => Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(
+                        library_item.to_owned(),
+                    )))
+                    .unchanged(),
+                    _ => Effects::none().unchanged(),
+                };
                 let selected_effects = eq_update(&mut self.selected, None);
                 let meta_item_effects = eq_update(&mut self.meta_item, None);
                 let subtitles_effects = eq_update(&mut self.subtitles, vec![]);
@@ -395,7 +401,13 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     }))
                     .unchanged()
                 };
-                let update_library_item_effects = update_library_item(&self.library_item);
+                let update_library_item_effects = match &self.library_item {
+                    Some(library_item) => Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(
+                        library_item.to_owned(),
+                    )))
+                    .unchanged(),
+                    _ => Effects::none().unchanged(),
+                };
                 trakt_event_effects.join(update_library_item_effects)
             }
             Msg::Action(Action::Player(ActionPlayer::Ended)) if self.selected.is_some() => {
@@ -486,17 +498,6 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
             }
             _ => Effects::none().unchanged(),
         }
-    }
-}
-
-/// Will add an [`Internal::UpdateLibraryItem`] message effect if `Some` is passed.
-fn update_library_item(library_item: &Option<LibraryItem>) -> Effects {
-    match library_item {
-        Some(library_item) => Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(
-            library_item.to_owned(),
-        )))
-        .unchanged(),
-        _ => Effects::none().unchanged(),
     }
 }
 
@@ -710,7 +711,13 @@ fn library_item_update<E: Env + 'static>(
         _ => None,
     };
     if *library_item != next_library_item {
-        let update_library_item_effects = update_library_item(library_item);
+        let update_library_item_effects = match library_item {
+            Some(library_item) => Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(
+                library_item.to_owned(),
+            )))
+            .unchanged(),
+            _ => Effects::none().unchanged(),
+        };
         *library_item = next_library_item;
         Effects::none().join(update_library_item_effects)
     } else {

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -339,9 +339,10 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     } else {
                         Effects::none()
                     };
-                    let push_to_api_effect = if self.api_push_time.is_none()
-                        || E::now() - self.api_push_time.unwrap() >= Duration::seconds(30)
+                    let push_to_api_effect = if E::now() - self.api_push_time.unwrap_or_default()
+                        >= Duration::seconds(30)
                     {
+                        self.api_push_time = Some(E::now());
                         Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(
                             library_item.to_owned(),
                         )))

--- a/src/runtime/effects.rs
+++ b/src/runtime/effects.rs
@@ -16,10 +16,25 @@ pub enum Effect {
     Future(EffectFuture),
 }
 
+/// # Examples
+///
+/// ```
+/// use stremio_core::runtime::Effects;
+///
+/// let none_unchanged = Effects::none().unchanged();
+/// let default = Effects::default();
+///
+/// assert_eq!(default.has_changed, false);
+/// assert!(none_unchanged.is_empty());
+/// assert!(default.is_empty());
+/// assert_eq!(none_unchanged.has_changed, default.has_changed);
+/// ```
 #[derive(IntoIterator)]
 pub struct Effects {
     #[into_iterator(owned)]
+    /// The effects to be applied
     effects: Vec<Effect>,
+    /// whether or not the effects are changing something
     pub has_changed: bool,
 }
 
@@ -62,5 +77,37 @@ impl Effects {
         self.has_changed = self.has_changed || effects.has_changed;
         self.effects.append(&mut effects.effects);
         self
+    }
+
+    /// Returns the amount of effects
+    pub fn len(&self) -> usize {
+        self.effects.len()
+    }
+
+    /// Returns whether there are any effects
+    pub fn is_empty(&self) -> bool {
+        self.effects.is_empty()
+    }
+}
+
+impl Default for Effects {
+    fn default() -> Self {
+        Self::none().unchanged()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_effects_defaults() {
+        let none_unchanged = Effects::none().unchanged();
+        let default = Effects::default();
+
+        assert_eq!(default.has_changed, false);
+        assert!(none_unchanged.is_empty());
+        assert!(default.is_empty());
+        assert_eq!(none_unchanged.has_changed, default.has_changed);
     }
 }

--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -104,7 +104,6 @@ pub enum ActionPlayer {
         paused: bool,
     },
     Ended,
-    PushToLibrary,
 }
 
 #[derive(Clone, Deserialize, Debug)]


### PR DESCRIPTION
Handle `push_to_api` behavior internally, instead of each individual implementation doing something differently and missing some push or having them too often.
Now it will push to api when updating time and check if at least 30s passed since the last update. As `update_time` is called on every video tick it should work just fine. 
Also push to api when stopping the video and when unloading the model.