### PR TITLE
feat: implement torrent stats for streaming server

### DIFF
--- a/src/models/streaming_server.rs
+++ b/src/models/streaming_server.rs
@@ -312,13 +312,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for StreamingServer {
             }
             Msg::Internal(Internal::StreamingServerStatisticsResult((url, request), result))
                 if self.selected.transport_url == *url
-                    && match &self.selected.statistics {
-                        Some(StatisticsRequest {
-                            info_hash,
-                            file_idx,
-                        }) => info_hash == &request.info_hash && file_idx == &request.file_idx,
-                        None => false,
-                    } =>
+                    && self.selected.statistics.as_ref() == Some(request) =>
             {
                 let loadable = match result {
                     Ok(statistics) => Loadable::Ready(statistics.to_owned()),

--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -71,6 +71,13 @@ pub enum CreateTorrentArgs {
 
 #[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+pub struct GetStatisticsArgs {
+    pub info_hash: String,
+    pub file_idx: u16,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct PlayOnDeviceArgs {
     pub device: String,
     pub source: String,
@@ -83,6 +90,7 @@ pub enum ActionStreamingServer {
     Reload,
     UpdateSettings(StreamingServerSettings),
     CreateTorrent(CreateTorrentArgs),
+    GetStatistics(GetStatisticsArgs),
     PlayOnDevice(PlayOnDeviceArgs),
 }
 

--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -6,7 +6,9 @@ use crate::models::library_by_type::Selected as LibraryByTypeSelected;
 use crate::models::library_with_filters::Selected as LibraryWithFiltersSelected;
 use crate::models::meta_details::Selected as MetaDetailsSelected;
 use crate::models::player::Selected as PlayerSelected;
-use crate::models::streaming_server::Settings as StreamingServerSettings;
+use crate::models::streaming_server::{
+    Settings as StreamingServerSettings, StatisticsRequest as StreamingServerStatisticsRequest,
+};
 use crate::types::addon::Descriptor;
 use crate::types::api::AuthRequest;
 use crate::types::profile::Settings as ProfileSettings;
@@ -71,13 +73,6 @@ pub enum CreateTorrentArgs {
 
 #[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct GetStatisticsArgs {
-    pub info_hash: String,
-    pub file_idx: u16,
-}
-
-#[derive(Clone, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
 pub struct PlayOnDeviceArgs {
     pub device: String,
     pub source: String,
@@ -90,7 +85,7 @@ pub enum ActionStreamingServer {
     Reload,
     UpdateSettings(StreamingServerSettings),
     CreateTorrent(CreateTorrentArgs),
-    GetStatistics(GetStatisticsArgs),
+    GetStatistics(StreamingServerStatisticsRequest),
     PlayOnDevice(PlayOnDeviceArgs),
 }
 

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -9,6 +9,7 @@ use crate::types::api::{
 };
 use crate::types::library::{LibraryBucket, LibraryItem};
 use crate::types::profile::{Auth, AuthKey, Profile, User};
+use crate::types::streaming_server::Statistics;
 use url::Url;
 
 pub type CtxStorageResponse = (
@@ -61,6 +62,8 @@ pub enum Internal {
     StreamingServerCreateTorrentResult(String, Result<(), EnvError>),
     // Result for playing on device.
     StreamingServerPlayOnDeviceResult(String, Result<(), EnvError>),
+    // Result for streaming server statistics.
+    StreamingServerStatisticsResult(Url, Result<Statistics, EnvError>),
     /// Result for fetching resource from addons.
     ResourceRequestResult(ResourceRequest, Box<Result<ResourceResponse, EnvError>>),
     /// Result for fetching manifest from addon.

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -1,6 +1,8 @@
 use crate::models::ctx::CtxError;
 use crate::models::link::LinkError;
-use crate::models::streaming_server::{PlaybackDevice, Settings as StreamingServerSettings};
+use crate::models::streaming_server::{
+    PlaybackDevice, Settings as StreamingServerSettings, StatisticsRequest,
+};
 use crate::runtime::EnvError;
 use crate::types::addon::{Descriptor, Manifest, ResourceRequest, ResourceResponse};
 use crate::types::api::{
@@ -63,7 +65,7 @@ pub enum Internal {
     // Result for playing on device.
     StreamingServerPlayOnDeviceResult(String, Result<(), EnvError>),
     // Result for streaming server statistics.
-    StreamingServerStatisticsResult(Url, String, u16, Result<Statistics, EnvError>),
+    StreamingServerStatisticsResult((Url, StatisticsRequest), Result<Statistics, EnvError>),
     /// Result for fetching resource from addons.
     ResourceRequestResult(ResourceRequest, Box<Result<ResourceResponse, EnvError>>),
     /// Result for fetching manifest from addon.

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -63,7 +63,7 @@ pub enum Internal {
     // Result for playing on device.
     StreamingServerPlayOnDeviceResult(String, Result<(), EnvError>),
     // Result for streaming server statistics.
-    StreamingServerStatisticsResult(Url, Result<Statistics, EnvError>),
+    StreamingServerStatisticsResult(Url, String, u16, Result<Statistics, EnvError>),
     /// Result for fetching resource from addons.
     ResourceRequestResult(ResourceRequest, Box<Result<ResourceResponse, EnvError>>),
     /// Result for fetching manifest from addon.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,6 +3,7 @@ pub mod api;
 pub mod library;
 pub mod profile;
 pub mod resource;
+pub mod streaming_server;
 
 mod query_params_encode;
 pub use query_params_encode::*;

--- a/src/types/streaming_server/mod.rs
+++ b/src/types/streaming_server/mod.rs
@@ -1,0 +1,2 @@
+mod statistics;
+pub use statistics::*;

--- a/src/types/streaming_server/statistics.rs
+++ b/src/types/streaming_server/statistics.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct File {
+    name: String,
+    path: String,
+    length: u64,
+    offset: u64,
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Growler {
+    flood: u64,
+    pulse: u64,
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PeerSearch {
+    max: u64,
+    min: u64,
+    sources: Vec<String>,
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SwarmCap {
+    max_speed: u64,
+    min_peers: u64,
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Options {
+    connections: u64,
+    dht: bool,
+    growler: Growler,
+    handshake_timeout: u64,
+    path: String,
+    peer_search: PeerSearch,
+    swarm_cap: SwarmCap,
+    timeout: u64,
+    tracker: bool,
+    r#virtual: bool,
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Source {
+    last_started: String,
+    num_found: u64,
+    num_found_uniq: u64,
+    num_requests: u64,
+    url: Url,
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Statistics {
+    name: String,
+    info_hash: String,
+    files: Vec<File>,
+    sources: Vec<Source>,
+    opts: Options,
+    download_speed: f64,
+    upload_speed: f64,
+    downloaded: u64,
+    uploaded: u64,
+    unchoked: u64,
+    peers: u64,
+    queued: u64,
+    unique: u64,
+    connection_tries: u64,
+    peer_search_running: bool,
+    stream_len: u64,
+    stream_name: String,
+    stream_progress: f64,
+    swarm_connections: u64,
+    swarm_paused: bool,
+    swarm_size: u64,
+}


### PR DESCRIPTION
New StremingServer action `GetStatistics`, takes `info_hash` and `file_idx` as arguments
It makes a request to the server route `/{infoHash}/{fileIdx}/stats.json`
Closes #437 