### PR TITLE
improve addon upgrade behaviour

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -72,6 +72,7 @@ lazy_static! {
         options_limit: OptionsLimit::default(),
     };
     pub static ref TYPE_PRIORITIES: HashMap<&'static str, i32> = vec![
+        ("all", 5),
         ("movie", 4),
         ("series", 3),
         ("channel", 2),

--- a/src/models/ctx/update_profile.rs
+++ b/src/models/ctx/update_profile.rs
@@ -101,54 +101,37 @@ pub fn update_profile<E: Env + 'static>(
             Effects::msg(Msg::Internal(Internal::InstallAddon(addon.to_owned()))).unchanged()
         }
         Msg::Action(Action::Ctx(ActionCtx::UpgradeAddon(addon))) => {
-            if !profile.addons.contains(addon) {
-                if !addon.manifest.behavior_hints.configuration_required {
-                    let addon_positions = profile
-                        .addons
-                        .iter()
-                        .map(|addon| &addon.manifest.id)
-                        .enumerate()
-                        .filter(|(_, id)| **id == addon.manifest.id && !addon.flags.protected)
-                        .map(|(position, _)| position)
-                        .collect::<Vec<_>>();
-                    for position in addon_positions {
-                        profile.addons.remove(position);
-                    }
-                    profile.addons.push(addon.to_owned());
-                    let push_to_api_effects = match profile.auth_key() {
-                        Some(auth_key) => Effects::one(push_addons_to_api::<E>(
-                            profile.addons.to_owned(),
-                            auth_key,
-                        ))
-                        .unchanged(),
-                        _ => Effects::none().unchanged(),
-                    };
-                    Effects::msg(Msg::Event(Event::AddonUpgraded {
-                        transport_url: addon.transport_url.to_owned(),
-                        id: addon.manifest.id.to_owned(),
-                    }))
-                    .join(push_to_api_effects)
-                    .join(Effects::msg(Msg::Internal(Internal::ProfileChanged)))
-                } else {
-                    Effects::msg(Msg::Event(Event::Error {
-                        error: CtxError::from(OtherError::AddonConfigurationRequired),
-                        source: Box::new(Event::AddonUpgraded {
-                            transport_url: addon.transport_url.to_owned(),
-                            id: addon.manifest.id.to_owned(),
-                        }),
-                    }))
-                    .unchanged()
-                }
-            } else {
-                Effects::msg(Msg::Event(Event::Error {
-                    error: CtxError::from(OtherError::AddonAlreadyInstalled),
-                    source: Box::new(Event::AddonUpgraded {
-                        transport_url: addon.transport_url.to_owned(),
-                        id: addon.manifest.id.to_owned(),
-                    }),
-                }))
-                .unchanged()
+            if profile.addons.contains(addon) {
+                return addon_upgrade_error_effects(addon, OtherError::AddonAlreadyInstalled);
             }
+            if addon.manifest.behavior_hints.configuration_required {
+                return addon_upgrade_error_effects(addon, OtherError::AddonConfigurationRequired);
+            }
+            let addon_position = profile
+                .addons
+                .iter()
+                .map(|addon| &addon.transport_url)
+                .position(|transport_url| *transport_url == addon.transport_url);
+            if addon_position.is_none() {
+                return addon_upgrade_error_effects(addon, OtherError::AddonNotInstalled);
+            }
+            if addon.flags.protected || profile.addons[addon_position.unwrap()].flags.protected {
+                return addon_upgrade_error_effects(addon, OtherError::AddonIsProtected);
+            }
+            profile.addons[addon_position.unwrap()] = addon.to_owned();
+            let push_to_api_effects = match profile.auth_key() {
+                Some(auth_key) => {
+                    Effects::one(push_addons_to_api::<E>(profile.addons.to_owned(), auth_key))
+                        .unchanged()
+                }
+                _ => Effects::none().unchanged(),
+            };
+            Effects::msg(Msg::Event(Event::AddonUpgraded {
+                transport_url: addon.transport_url.to_owned(),
+                id: addon.manifest.id.to_owned(),
+            }))
+            .join(push_to_api_effects)
+            .join(Effects::msg(Msg::Internal(Internal::ProfileChanged)))
         }
         Msg::Action(Action::Ctx(ActionCtx::UninstallAddon(addon))) => {
             let addon_position = profile
@@ -157,7 +140,7 @@ pub fn update_profile<E: Env + 'static>(
                 .map(|addon| &addon.transport_url)
                 .position(|transport_url| *transport_url == addon.transport_url);
             if let Some(addon_position) = addon_position {
-                if !profile.addons[addon_position].flags.protected {
+                if !profile.addons[addon_position].flags.protected && !addon.flags.protected {
                     profile.addons.remove(addon_position);
                     let push_to_api_effects = match profile.auth_key() {
                         Some(auth_key) => Effects::one(push_addons_to_api::<E>(
@@ -174,24 +157,10 @@ pub fn update_profile<E: Env + 'static>(
                     .join(push_to_api_effects)
                     .join(Effects::msg(Msg::Internal(Internal::ProfileChanged)))
                 } else {
-                    Effects::msg(Msg::Event(Event::Error {
-                        error: CtxError::from(OtherError::AddonIsProtected),
-                        source: Box::new(Event::AddonUninstalled {
-                            transport_url: addon.transport_url.to_owned(),
-                            id: addon.manifest.id.to_owned(),
-                        }),
-                    }))
-                    .unchanged()
+                    addon_uninstall_error_effects(addon, OtherError::AddonIsProtected)
                 }
             } else {
-                Effects::msg(Msg::Event(Event::Error {
-                    error: CtxError::from(OtherError::AddonNotInstalled),
-                    source: Box::new(Event::AddonUninstalled {
-                        transport_url: addon.transport_url.to_owned(),
-                        id: addon.manifest.id.to_owned(),
-                    }),
-                }))
-                .unchanged()
+                addon_uninstall_error_effects(addon, OtherError::AddonNotInstalled)
             }
         }
         Msg::Action(Action::Ctx(ActionCtx::LogoutTrakt)) => match &mut profile.auth {
@@ -259,37 +228,23 @@ pub fn update_profile<E: Env + 'static>(
                     .join(push_to_api_effects)
                     .join(Effects::msg(Msg::Internal(Internal::ProfileChanged)))
                 } else {
-                    Effects::msg(Msg::Event(Event::Error {
-                        error: CtxError::from(OtherError::AddonConfigurationRequired),
-                        source: Box::new(Event::AddonInstalled {
-                            transport_url: addon.transport_url.to_owned(),
-                            id: addon.manifest.id.to_owned(),
-                        }),
-                    }))
-                    .unchanged()
+                    addon_install_error_effects(addon, OtherError::AddonConfigurationRequired)
                 }
             } else {
-                Effects::msg(Msg::Event(Event::Error {
-                    error: CtxError::from(OtherError::AddonAlreadyInstalled),
-                    source: Box::new(Event::AddonInstalled {
-                        transport_url: addon.transport_url.to_owned(),
-                        id: addon.manifest.id.to_owned(),
-                    }),
-                }))
-                .unchanged()
+                addon_install_error_effects(addon, OtherError::AddonAlreadyInstalled)
             }
         }
         Msg::Internal(Internal::CtxAuthResult(auth_request, result)) => match (status, result) {
             (CtxStatus::Loading(loading_auth_request), Ok((auth, addons, _)))
                 if loading_auth_request == auth_request =>
             {
-                let next_proifle = Profile {
+                let next_profile = Profile {
                     auth: Some(auth.to_owned()),
                     addons: addons.to_owned(),
                     settings: Settings::default(),
                 };
-                if *profile != next_proifle {
-                    *profile = next_proifle;
+                if *profile != next_profile {
+                    *profile = next_profile;
                     Effects::msg(Msg::Internal(Internal::ProfileChanged))
                 } else {
                     Effects::none().unchanged()
@@ -460,4 +415,42 @@ fn push_profile_to_storage<E: Env + 'static>(profile: &Profile) -> Effect {
             .boxed_env(),
     )
     .into()
+}
+
+fn addon_upgrade_error_effects(addon: &Descriptor, error: OtherError) -> Effects {
+    addon_action_error_effects(
+        error,
+        Event::AddonUpgraded {
+            transport_url: addon.transport_url.to_owned(),
+            id: addon.manifest.id.to_owned(),
+        },
+    )
+}
+
+fn addon_uninstall_error_effects(addon: &Descriptor, error: OtherError) -> Effects {
+    addon_action_error_effects(
+        error,
+        Event::AddonUninstalled {
+            transport_url: addon.transport_url.to_owned(),
+            id: addon.manifest.id.to_owned(),
+        },
+    )
+}
+
+fn addon_install_error_effects(addon: &Descriptor, error: OtherError) -> Effects {
+    addon_action_error_effects(
+        error,
+        Event::AddonInstalled {
+            transport_url: addon.transport_url.to_owned(),
+            id: addon.manifest.id.to_owned(),
+        },
+    )
+}
+
+fn addon_action_error_effects(error: OtherError, source: Event) -> Effects {
+    Effects::msg(Msg::Event(Event::Error {
+        error: CtxError::from(error),
+        source: Box::new(source),
+    }))
+    .unchanged()
 }

--- a/src/unit_tests/ctx/upgrade_addon.rs
+++ b/src/unit_tests/ctx/upgrade_addon.rs
@@ -35,7 +35,7 @@ fn actionctx_addon_upgrade() {
         transport_url: Url::parse("https://transport_url").unwrap(),
         flags: Default::default(),
     };
-    let addon2 = Descriptor {
+    let addon1_update = Descriptor {
         manifest: Manifest {
             id: "id1".to_owned(),
             version: Version::new(0, 0, 2),
@@ -54,7 +54,7 @@ fn actionctx_addon_upgrade() {
         transport_url: Url::parse("https://transport_url").unwrap(),
         flags: Default::default(),
     };
-    let addon3 = Descriptor {
+    let addon2 = Descriptor {
         manifest: Manifest {
             id: "id2".to_owned(),
             version: Version::new(0, 0, 1),
@@ -78,7 +78,7 @@ fn actionctx_addon_upgrade() {
         TestModel {
             ctx: Ctx {
                 profile: Profile {
-                    addons: vec![addon1.to_owned(), addon3.to_owned()],
+                    addons: vec![addon1.to_owned(), addon2.to_owned()],
                     ..Default::default()
                 },
                 ..Default::default()
@@ -90,10 +90,10 @@ fn actionctx_addon_upgrade() {
     TestEnv::run(|| {
         runtime.dispatch(RuntimeAction {
             field: None,
-            action: Action::Ctx(ActionCtx::UpgradeAddon(addon2.to_owned())),
+            action: Action::Ctx(ActionCtx::UpgradeAddon(addon1_update.to_owned())),
         })
     });
-    let expected = vec![addon2.to_owned(), addon3.to_owned()];
+    let expected = vec![addon1_update.to_owned(), addon2.to_owned()];
 
     assert_eq!(
         runtime.model().unwrap().ctx.profile.addons,


### PR DESCRIPTION
Currently when upgrading addon it checks for installed addons based on `id` and replaces all of them with the new one. But this is flawed, since addons might have the same `id`, but different configuration and that's not what the user would expect, he'd expect to upgrade the same addon with the same configuration to the new manifest version. So I'm updating this function to reflect that.
Also fix a bug which allowed upgrading `protected` addon, which would add a second addon with the same `transportUrl`. Same was possible for uninstall, as I had a case where in my profile `cinemeta` was stored without `protected` variable and was able to uninstall it, so check both the local and passed addon flags as usually the passed addon would be the remote one, which would have the flag.