### PR TITLE
Streams bucket patch

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,6 +8,7 @@ pub const SCHEMA_VERSION_STORAGE_KEY: &str = "schema_version";
 pub const PROFILE_STORAGE_KEY: &str = "profile";
 pub const LIBRARY_STORAGE_KEY: &str = "library";
 pub const LIBRARY_RECENT_STORAGE_KEY: &str = "library_recent";
+pub const STREAMS_STORAGE_KEY: &str = "streams";
 pub const LIBRARY_COLLECTION_NAME: &str = "libraryItem";
 pub const SEARCH_EXTRA_NAME: &str = "search";
 pub const META_RESOURCE_NAME: &str = "meta";

--- a/src/models/ctx/ctx.rs
+++ b/src/models/ctx/ctx.rs
@@ -2,7 +2,7 @@ use crate::constants::{LIBRARY_COLLECTION_NAME, URI_COMPONENT_ENCODE_SET};
 use crate::models::common::{
     descriptor_update, eq_update, DescriptorAction, DescriptorLoadable, Loadable,
 };
-use crate::models::ctx::{update_library, update_profile, CtxError, OtherError};
+use crate::models::ctx::{update_library, update_profile, update_streams, CtxError, OtherError};
 use crate::runtime::msg::{Action, ActionCtx, Event, Internal, Msg};
 use crate::runtime::{Effect, EffectFuture, Effects, Env, EnvFutureExt, Update};
 use crate::types::api::{
@@ -11,6 +11,7 @@ use crate::types::api::{
 };
 use crate::types::library::LibraryBucket;
 use crate::types::profile::{Auth, AuthKey, Profile};
+use crate::types::streams::StreamsBucket;
 
 use derivative::Derivative;
 use enclose::enclose;
@@ -31,11 +32,12 @@ pub enum CtxStatus {
 #[derivative(Default)]
 pub struct Ctx {
     pub profile: Profile,
-    // TODO StreamsBucket
     // TODO SubtitlesBucket
     // TODO SearchesBucket
     #[serde(skip)]
     pub library: LibraryBucket,
+    #[serde(skip)]
+    pub streams: StreamsBucket,
     #[serde(skip)]
     #[derivative(Default(value = "CtxStatus::Ready"))]
     pub status: CtxStatus,
@@ -44,10 +46,11 @@ pub struct Ctx {
 }
 
 impl Ctx {
-    pub fn new(profile: Profile, library: LibraryBucket) -> Self {
+    pub fn new(profile: Profile, library: LibraryBucket, streams: StreamsBucket) -> Self {
         Self {
             profile,
             library,
+            streams,
             ..Self::default()
         }
     }
@@ -72,6 +75,7 @@ impl<E: Env + 'static> Update<E> for Ctx {
                 let profile_effects = update_profile::<E>(&mut self.profile, &self.status, msg);
                 let library_effects =
                     update_library::<E>(&mut self.library, &self.profile, &self.status, msg);
+                let streams_effects = update_streams::<E>(&mut self.streams, &self.status, msg);
                 let trakt_addon_effects = eq_update(&mut self.trakt_addon, None);
                 self.status = CtxStatus::Ready;
                 Effects::msg(Msg::Event(Event::UserLoggedOut { uid }))
@@ -79,6 +83,7 @@ impl<E: Env + 'static> Update<E> for Ctx {
                     .join(session_effects)
                     .join(profile_effects)
                     .join(library_effects)
+                    .join(streams_effects)
                     .join(trakt_addon_effects)
             }
             Msg::Action(Action::Ctx(ActionCtx::InstallTraktAddon)) => {
@@ -141,6 +146,7 @@ impl<E: Env + 'static> Update<E> for Ctx {
                 let profile_effects = update_profile::<E>(&mut self.profile, &self.status, msg);
                 let library_effects =
                     update_library::<E>(&mut self.library, &self.profile, &self.status, msg);
+                let streams_effects = update_streams::<E>(&mut self.streams, &self.status, msg);
                 let ctx_effects = match &self.status {
                     CtxStatus::Loading(loading_auth_request)
                         if loading_auth_request == auth_request =>
@@ -162,13 +168,17 @@ impl<E: Env + 'static> Update<E> for Ctx {
                     }
                     _ => Effects::none().unchanged(),
                 };
-                profile_effects.join(library_effects).join(ctx_effects)
+                profile_effects
+                    .join(library_effects)
+                    .join(streams_effects)
+                    .join(ctx_effects)
             }
             _ => {
                 let profile_effects = update_profile::<E>(&mut self.profile, &self.status, msg);
                 let library_effects =
                     update_library::<E>(&mut self.library, &self.profile, &self.status, msg);
-                profile_effects.join(library_effects)
+                let streams_effects = update_streams::<E>(&mut self.streams, &self.status, msg);
+                profile_effects.join(library_effects).join(streams_effects)
             }
         }
     }

--- a/src/models/ctx/mod.rs
+++ b/src/models/ctx/mod.rs
@@ -4,6 +4,9 @@ use update_library::*;
 mod update_profile;
 use update_profile::*;
 
+mod update_streams;
+use update_streams::*;
+
 mod error;
 pub use error::*;
 

--- a/src/models/ctx/update_streams.rs
+++ b/src/models/ctx/update_streams.rs
@@ -1,0 +1,75 @@
+use enclose::enclose;
+use futures::FutureExt;
+
+use crate::constants::STREAMS_STORAGE_KEY;
+use crate::models::ctx::{CtxError, CtxStatus};
+use crate::runtime::msg::{Action, ActionCtx, Event, Internal, Msg};
+use crate::runtime::{Effect, EffectFuture, Effects, Env, EnvFutureExt};
+use crate::types::streams::{StreamsBucket, StreamsItem};
+
+pub fn update_streams<E: Env + 'static>(
+    streams: &mut StreamsBucket,
+    status: &CtxStatus,
+    msg: &Msg,
+) -> Effects {
+    match msg {
+        Msg::Action(Action::Ctx(ActionCtx::Logout)) | Msg::Internal(Internal::Logout) => {
+            let next_streams = StreamsBucket::default();
+            if *streams != next_streams {
+                *streams = next_streams;
+                Effects::msg(Msg::Internal(Internal::StreamsChanged(false)))
+            } else {
+                Effects::none().unchanged()
+            }
+        }
+        Msg::Internal(Internal::StreamLoaded(
+            Some(meta_item_id),
+            Some(video_id),
+            Some(transport_url),
+            stream,
+        )) => {
+            let streams_item = StreamsItem {
+                stream: stream.to_owned(),
+                transport_url: transport_url.to_owned(),
+                mtime: E::now(),
+            };
+            streams
+                .items
+                .insert((meta_item_id.to_owned(), video_id.to_owned()), streams_item);
+            Effects::msg(Msg::Internal(Internal::StreamsChanged(false)))
+        }
+        Msg::Internal(Internal::StreamsChanged(persisted)) if !persisted => {
+            Effects::one(push_streams_to_storage::<E>(streams)).unchanged()
+        }
+        Msg::Internal(Internal::CtxAuthResult(auth_request, result)) => match (status, result) {
+            (CtxStatus::Loading(loading_auth_request), Ok((auth, _, _)))
+                if loading_auth_request == auth_request =>
+            {
+                let next_streams = StreamsBucket::new(Some(auth.user.id.to_owned()));
+                if *streams != next_streams {
+                    *streams = next_streams;
+                    Effects::msg(Msg::Internal(Internal::StreamsChanged(false)))
+                } else {
+                    Effects::none().unchanged()
+                }
+            }
+            _ => Effects::none().unchanged(),
+        },
+        _ => Effects::none().unchanged(),
+    }
+}
+
+fn push_streams_to_storage<E: Env + 'static>(streams: &StreamsBucket) -> Effect {
+    EffectFuture::Sequential(
+        E::set_storage(STREAMS_STORAGE_KEY, Some(&streams))
+            .map(enclose!((streams.uid => uid) move |result| match result {
+                Ok(_) => Msg::Event(Event::StreamsPushedToStorage { uid }),
+                Err(error) => Msg::Event(Event::Error {
+                    error: CtxError::from(error),
+                    source: Box::new(Event::StreamsPushedToStorage { uid }),
+                })
+            }))
+            .boxed_env(),
+    )
+    .into()
+}

--- a/src/models/ctx/update_streams.rs
+++ b/src/models/ctx/update_streams.rs
@@ -2,7 +2,7 @@ use crate::constants::STREAMS_STORAGE_KEY;
 use crate::models::ctx::{CtxError, CtxStatus};
 use crate::runtime::msg::{Action, ActionCtx, Event, Internal, Msg};
 use crate::runtime::{Effect, EffectFuture, Effects, Env, EnvFutureExt};
-use crate::types::streams::{StreamsBucket, StreamsItem};
+use crate::types::streams::{StreamsBucket, StreamsItem, StreamsItemKey};
 use enclose::enclose;
 use futures::FutureExt;
 
@@ -27,14 +27,16 @@ pub fn update_streams<E: Env + 'static>(
             video_id: Some(video_id),
             transport_url: Some(transport_url),
         }) => {
+            let key = StreamsItemKey {
+                meta_id: meta_id.to_owned(),
+                video_id: video_id.to_owned(),
+            };
             let streams_item = StreamsItem {
                 stream: stream.to_owned(),
                 transport_url: transport_url.to_owned(),
                 mtime: E::now(),
             };
-            streams
-                .items
-                .insert((meta_id.to_owned(), video_id.to_owned()), streams_item);
+            streams.items.insert(key, streams_item);
             Effects::msg(Msg::Internal(Internal::StreamsChanged(false)))
         }
         Msg::Internal(Internal::StreamsChanged(persisted)) if !persisted => {

--- a/src/models/ctx/update_streams.rs
+++ b/src/models/ctx/update_streams.rs
@@ -21,12 +21,12 @@ pub fn update_streams<E: Env + 'static>(
                 Effects::none().unchanged()
             }
         }
-        Msg::Internal(Internal::StreamLoaded(
-            Some(meta_item_id),
-            Some(video_id),
-            Some(transport_url),
+        Msg::Internal(Internal::StreamLoaded {
             stream,
-        )) => {
+            meta_id: Some(meta_id),
+            video_id: Some(video_id),
+            transport_url: Some(transport_url),
+        }) => {
             let streams_item = StreamsItem {
                 stream: stream.to_owned(),
                 transport_url: transport_url.to_owned(),
@@ -34,7 +34,7 @@ pub fn update_streams<E: Env + 'static>(
             };
             streams
                 .items
-                .insert((meta_item_id.to_owned(), video_id.to_owned()), streams_item);
+                .insert((meta_id.to_owned(), video_id.to_owned()), streams_item);
             Effects::msg(Msg::Internal(Internal::StreamsChanged(false)))
         }
         Msg::Internal(Internal::StreamsChanged(persisted)) if !persisted => {

--- a/src/models/ctx/update_streams.rs
+++ b/src/models/ctx/update_streams.rs
@@ -1,11 +1,10 @@
-use enclose::enclose;
-use futures::FutureExt;
-
 use crate::constants::STREAMS_STORAGE_KEY;
 use crate::models::ctx::{CtxError, CtxStatus};
 use crate::runtime::msg::{Action, ActionCtx, Event, Internal, Msg};
 use crate::runtime::{Effect, EffectFuture, Effects, Env, EnvFutureExt};
 use crate::types::streams::{StreamsBucket, StreamsItem};
+use enclose::enclose;
+use futures::FutureExt;
 
 pub fn update_streams<E: Env + 'static>(
     streams: &mut StreamsBucket,

--- a/src/models/ctx/update_streams.rs
+++ b/src/models/ctx/update_streams.rs
@@ -33,6 +33,8 @@ pub fn update_streams<E: Env + 'static>(
             };
             let streams_item = StreamsItem {
                 stream: stream.to_owned(),
+                meta_id: meta_id.to_owned(),
+                video_id: video_id.to_owned(),
                 transport_url: transport_url.to_owned(),
                 mtime: E::now(),
             };

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -127,21 +127,21 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     &selected.stream_request,
                     &selected.meta_request,
                 )) {
-                    Effects::msg(Msg::Internal(Internal::StreamLoaded(
-                        selected
+                    Effects::msg(Msg::Internal(Internal::StreamLoaded {
+                        stream: selected.stream.to_owned(),
+                        meta_id: selected
                             .meta_request
                             .as_ref()
                             .map(|meta_request| meta_request.path.id.to_owned()),
-                        selected
+                        video_id: selected
                             .stream_request
                             .as_ref()
                             .map(|stream_request| stream_request.path.id.to_owned()),
-                        selected
+                        transport_url: selected
                             .stream_request
                             .as_ref()
                             .map(|stream_request| stream_request.base.to_owned()),
-                        selected.stream.to_owned(),
-                    )))
+                    }))
                     .unchanged()
                 } else {
                     Effects::none().unchanged()

--- a/src/runtime/msg/event.rs
+++ b/src/runtime/msg/event.rs
@@ -36,6 +36,9 @@ pub enum Event {
     LibraryItemsPushedToStorage {
         ids: Vec<String>,
     },
+    StreamsPushedToStorage {
+        uid: UID,
+    },
     UserPulledFromAPI {
         uid: UID,
     },

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -45,7 +45,12 @@ pub enum Internal {
     /// Dispatched when addons needs to be installed.
     InstallAddon(Descriptor),
     /// Dispatched when a new stream is loaded into the Player.
-    StreamLoaded(Option<String>, Option<String>, Option<Url>, Stream),
+    StreamLoaded {
+        stream: Stream,
+        meta_id: Option<String>,
+        video_id: Option<String>,
+        transport_url: Option<Url>,
+    },
     /// Dispatched when library item needs to be updated in the memory, storage and API.
     UpdateLibraryItem(LibraryItem),
     /// Dispatched when some of auth, addons or settings changed.

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -11,6 +11,7 @@ use crate::types::api::{
 };
 use crate::types::library::{LibraryBucket, LibraryItem};
 use crate::types::profile::{Auth, AuthKey, Profile, User};
+use crate::types::resource::Stream;
 use crate::types::streaming_server::Statistics;
 use url::Url;
 
@@ -43,12 +44,16 @@ pub enum Internal {
     Logout,
     /// Dispatched when addons needs to be installed.
     InstallAddon(Descriptor),
+    /// Dispatched when a new stream is loaded into the Player.
+    StreamLoaded(Option<String>, Option<String>, Option<Url>, Stream),
     /// Dispatched when library item needs to be updated in the memory, storage and API.
     UpdateLibraryItem(LibraryItem),
     /// Dispatched when some of auth, addons or settings changed.
     ProfileChanged,
     /// Dispatched when library changes with a flag if its already persisted.
     LibraryChanged(bool),
+    /// Dispatched when streams bucket changes with a flag if its already persisted.
+    StreamsChanged(bool),
     /// Result for loading link code.
     LinkCodeResult(Result<LinkCodeResponse, LinkError>),
     /// Result for loading link data.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,6 +4,7 @@ pub mod library;
 pub mod profile;
 pub mod resource;
 pub mod streaming_server;
+pub mod streams;
 
 mod query_params_encode;
 pub use query_params_encode::*;

--- a/src/types/streams/mod.rs
+++ b/src/types/streams/mod.rs
@@ -1,0 +1,5 @@
+mod streams_item;
+pub use streams_item::*;
+
+mod streams_bucket;
+pub use streams_bucket::*;

--- a/src/types/streams/streams_bucket.rs
+++ b/src/types/streams/streams_bucket.rs
@@ -1,14 +1,11 @@
-use std::collections::HashMap;
-
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
-
 use crate::types::profile::UID;
 use crate::types::streams::StreamsItem;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use std::collections::HashMap;
 
 #[serde_as]
-#[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamsBucket {
     pub uid: UID,
     #[serde_as(as = "Vec<(_, _)>")]

--- a/src/types/streams/streams_bucket.rs
+++ b/src/types/streams/streams_bucket.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use crate::types::profile::UID;
+use crate::types::streams::StreamsItem;
+
+#[serde_as]
+#[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct StreamsBucket {
+    pub uid: UID,
+    #[serde_as(as = "Vec<(_, _)>")]
+    pub items: HashMap<(String, String), StreamsItem>,
+}
+
+impl StreamsBucket {
+    pub fn new(uid: UID) -> Self {
+        StreamsBucket {
+            uid,
+            items: HashMap::new(),
+        }
+    }
+}

--- a/src/types/streams/streams_bucket.rs
+++ b/src/types/streams/streams_bucket.rs
@@ -4,12 +4,18 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::HashMap;
 
+#[derive(Default, Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct StreamsItemKey {
+    pub meta_id: String,
+    pub video_id: String,
+}
+
 #[serde_as]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamsBucket {
     pub uid: UID,
     #[serde_as(as = "Vec<(_, _)>")]
-    pub items: HashMap<(String, String), StreamsItem>,
+    pub items: HashMap<StreamsItemKey, StreamsItem>,
 }
 
 impl StreamsBucket {

--- a/src/types/streams/streams_bucket.rs
+++ b/src/types/streams/streams_bucket.rs
@@ -5,6 +5,7 @@ use serde_with::serde_as;
 use std::collections::HashMap;
 
 #[derive(Default, Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StreamsItemKey {
     pub meta_id: String,
     pub video_id: String,

--- a/src/types/streams/streams_item.rs
+++ b/src/types/streams/streams_item.rs
@@ -1,13 +1,11 @@
+use crate::types::resource::Stream;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use url::Url;
 
-use crate::types::resource::Stream;
-
 #[serde_as]
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StreamsItem {
     pub stream: Stream,
     pub transport_url: Url,

--- a/src/types/streams/streams_item.rs
+++ b/src/types/streams/streams_item.rs
@@ -6,6 +6,7 @@ use url::Url;
 
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StreamsItem {
     pub stream: Stream,
     pub meta_id: String,

--- a/src/types/streams/streams_item.rs
+++ b/src/types/streams/streams_item.rs
@@ -8,6 +8,8 @@ use url::Url;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StreamsItem {
     pub stream: Stream,
+    pub meta_id: String,
+    pub video_id: String,
     pub transport_url: Url,
     pub mtime: DateTime<Utc>,
 }

--- a/src/types/streams/streams_item.rs
+++ b/src/types/streams/streams_item.rs
@@ -12,5 +12,7 @@ pub struct StreamsItem {
     pub meta_id: String,
     pub video_id: String,
     pub transport_url: Url,
+    /// Modification time
+    #[serde(rename = "_mtime")]
     pub mtime: DateTime<Utc>,
 }

--- a/src/types/streams/streams_item.rs
+++ b/src/types/streams/streams_item.rs
@@ -1,0 +1,15 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use url::Url;
+
+use crate::types::resource::Stream;
+
+#[serde_as]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct StreamsItem {
+    pub stream: Stream,
+    pub transport_url: Url,
+    pub mtime: DateTime<Utc>,
+}


### PR DESCRIPTION
Based on #337 
- fixed conflicts
- refactored to not handle player events in ctx
- Should we allow multiple streams per mata_id/video_id?
- Should we implement a cleanup function in this pr?
- Should we add duration/offset or progress ratio to the StreamItem?

