### PR TITLE
override meta details selected based on loaded meta

### DIFF
--- a/src/models/link.rs
+++ b/src/models/link.rs
@@ -31,7 +31,7 @@ impl fmt::Display for LinkError {
     }
 }
 
-#[derive(Derivative, Serialize, Debug)]
+#[derive(Derivative, Serialize, Clone, Debug)]
 #[derivative(Default(bound = ""))]
 #[serde(rename_all = "camelCase")]
 pub struct Link<T> {

--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -205,16 +205,14 @@ fn selected_override_update(
     selected: &mut Option<Selected>,
     meta_items: &Vec<ResourceLoadable<MetaItem>>,
 ) -> Effects {
-    let meta_path = if let Some(Selected {
-        meta_path,
-        stream_path: None,
-    }) = &selected
-    {
-        meta_path
-    } else {
-        return Effects::default();
+    let meta_path = match &selected {
+        Some(Selected {
+            meta_path,
+            stream_path: None,
+        }) => meta_path,
+        None => return Effects::default(),
     };
-    let meta_item = if let Some(meta_item) = meta_items
+    let meta_item = match meta_items
         .iter()
         .find_map(|meta_item| match &meta_item.content {
             Some(Loadable::Ready(meta_item)) => Some(Some(meta_item)),
@@ -223,9 +221,8 @@ fn selected_override_update(
         })
         .flatten()
     {
-        meta_item
-    } else {
-        return Effects::default();
+        Some(meta_item) => meta_item,
+        _ => return Effects::default(),
     };
     let video_id = match (
         meta_item.videos.len(),

--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -112,7 +112,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for MetaDetails {
                     &mut self.meta_items,
                     ResourcesAction::ResourceRequestResult { request, result },
                 );
-                let selected_effects: Effects =
+                let selected_effects =
                     selected_override_update(&mut self.selected, &self.meta_items);
                 let streams_effects = if selected_effects.has_changed {
                     streams_update::<E>(&mut self.streams, &self.selected, &ctx.profile)

--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -214,7 +214,7 @@ fn selected_override_update(
     } else {
         return Effects::default();
     };
-    let viable_meta_item = if let Some(viable_meta_item) = meta_items
+    let meta_item = if let Some(meta_item) = meta_items
         .iter()
         .find_map(|meta_item| match &meta_item.content {
             Some(Loadable::Ready(meta_item)) => Some(Some(meta_item)),
@@ -223,17 +223,17 @@ fn selected_override_update(
         })
         .flatten()
     {
-        viable_meta_item
+        meta_item
     } else {
         return Effects::default();
     };
     let video_id = match (
-        viable_meta_item.videos.len(),
-        &viable_meta_item.preview.behavior_hints.default_video_id,
+        meta_item.videos.len(),
+        &meta_item.preview.behavior_hints.default_video_id,
     ) {
         (_, Some(default_video_id)) => default_video_id.to_owned(),
-        (1, _) => viable_meta_item.videos.first().unwrap().id.to_owned(),
-        (0, None) => viable_meta_item.preview.id.to_owned(),
+        (1, _) => meta_item.videos.first().unwrap().id.to_owned(),
+        (0, None) => meta_item.preview.id.to_owned(),
         _ => return Effects::default(),
     };
     eq_update(

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, LockResult, RwLock, RwLockReadGuard};
 #[derive(Serialize, Debug, PartialEq)]
 #[serde(tag = "name", content = "args")]
 pub enum RuntimeEvent<E: Env, M: Model<E>> {
-    NewState(Vec<M::Field>, M),
+    NewState(Vec<M::Field>, #[cfg(test)] M),
     CoreEvent(Event),
 }
 
@@ -78,8 +78,13 @@ where
     }
     fn handle_effects(&self, effects: Vec<Effect>, fields: Vec<M::Field>) {
         if !fields.is_empty() {
+            #[cfg(test)]
             let model = self.model.read().expect("model read failed");
-            self.emit(RuntimeEvent::<E, M>::NewState(fields, model.to_owned()));
+            self.emit(RuntimeEvent::<E, M>::NewState(
+                fields,
+                #[cfg(test)]
+                model.to_owned(),
+            ));
         };
         effects
             .into_iter()

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, LockResult, RwLock, RwLockReadGuard};
 #[derive(Serialize, Debug, PartialEq)]
 #[serde(tag = "name", content = "args")]
 pub enum RuntimeEvent<E: Env, M: Model<E>> {
-    NewState(Vec<M::Field>),
+    NewState(Vec<M::Field>, M),
     CoreEvent(Event),
 }
 
@@ -78,7 +78,8 @@ where
     }
     fn handle_effects(&self, effects: Vec<Effect>, fields: Vec<M::Field>) {
         if !fields.is_empty() {
-            self.emit(RuntimeEvent::<E, M>::NewState(fields));
+            let model = self.model.read().expect("model read failed");
+            self.emit(RuntimeEvent::<E, M>::NewState(fields, model.to_owned()));
         };
         effects
             .into_iter()

--- a/src/runtime/update.rs
+++ b/src/runtime/update.rs
@@ -5,7 +5,7 @@ use crate::runtime::{Effect, Effects, Env};
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
-pub trait Model<E: Env> {
+pub trait Model<E: Env>: Clone {
     #[cfg(not(debug_assertions))]
     type Field: Send + Sync + Serialize + for<'de> Deserialize<'de>;
     #[cfg(debug_assertions)]

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -218,6 +218,7 @@ pub struct SeriesInfo {
 
 #[serde_as]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[cfg_attr(test, derive(Default))]
 #[serde(rename_all = "camelCase")]
 pub struct Video {
     pub id: String,

--- a/src/unit_tests/catalog_with_filters/load_action.rs
+++ b/src/unit_tests/catalog_with_filters/load_action.rs
@@ -65,13 +65,13 @@ fn default_catalog() {
         events[0]
             .downcast_ref::<RuntimeEvent<TestEnv, TestModel>>()
             .unwrap(),
-        RuntimeEvent::NewState(fields) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::Discover
+        RuntimeEvent::NewState(fields, _) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::Discover
     );
     assert_matches!(
         events[1]
             .downcast_ref::<RuntimeEvent<TestEnv, TestModel>>()
             .unwrap(),
-        RuntimeEvent::NewState(fields) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::Discover
+        RuntimeEvent::NewState(fields, _) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::Discover
     );
     let states = STATES.read().unwrap();
     let states = states
@@ -173,13 +173,13 @@ fn search_catalog() {
         events[0]
             .downcast_ref::<RuntimeEvent<TestEnv, TestModel>>()
             .unwrap(),
-        RuntimeEvent::NewState(fields) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::Discover
+        RuntimeEvent::NewState(fields, _) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::Discover
     );
     assert_matches!(
         events[1]
             .downcast_ref::<RuntimeEvent<TestEnv, TestModel>>()
             .unwrap(),
-        RuntimeEvent::NewState(fields) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::Discover
+        RuntimeEvent::NewState(fields, _) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::Discover
     );
     let states = STATES.read().unwrap();
     let states = states

--- a/src/unit_tests/ctx/add_to_library.rs
+++ b/src/unit_tests/ctx/add_to_library.rs
@@ -18,7 +18,7 @@ use url::Url;
 
 #[test]
 fn actionctx_addtolibrary() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -159,7 +159,7 @@ fn actionctx_addtolibrary() {
 
 #[test]
 fn actionctx_addtolibrary_already_added() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/authenticate.rs
+++ b/src/unit_tests/ctx/authenticate.rs
@@ -19,7 +19,7 @@ use stremio_derive::Model;
 
 #[test]
 fn actionctx_authenticate_login() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -218,7 +218,7 @@ fn actionctx_authenticate_login() {
 
 #[test]
 fn actionctx_authenticate_login_with_token() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -416,7 +416,7 @@ fn actionctx_authenticate_login_with_token() {
 
 #[test]
 fn actionctx_authenticate_register() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/install_addon.rs
+++ b/src/unit_tests/ctx/install_addon.rs
@@ -17,7 +17,7 @@ use url::Url;
 
 #[test]
 fn actionctx_installaddon_install() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -84,7 +84,7 @@ fn actionctx_installaddon_install() {
 
 #[test]
 fn actionctx_installaddon_install_with_user() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -198,7 +198,7 @@ fn actionctx_installaddon_install_with_user() {
 
 #[test]
 fn actionctx_installaddon_update() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -306,7 +306,7 @@ fn actionctx_installaddon_update() {
 
 #[test]
 fn actionctx_installaddon_already_installed() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/logout.rs
+++ b/src/unit_tests/ctx/logout.rs
@@ -15,7 +15,7 @@ use stremio_derive::Model;
 
 #[test]
 fn actionctx_logout() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/pull_addons_from_api.rs
+++ b/src/unit_tests/ctx/pull_addons_from_api.rs
@@ -16,7 +16,7 @@ use url::Url;
 
 #[test]
 fn actionctx_pulladdonsfromapi() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -73,7 +73,7 @@ fn actionctx_pulladdonsfromapi() {
 
 #[test]
 fn actionctx_pulladdonsfromapi_with_user() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/push_addons_to_api.rs
+++ b/src/unit_tests/ctx/push_addons_to_api.rs
@@ -14,7 +14,7 @@ use url::Url;
 
 #[test]
 fn actionctx_pushaddonstoapi() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -65,7 +65,7 @@ fn actionctx_pushaddonstoapi() {
 
 #[test]
 fn actionctx_pushaddonstoapi_with_user() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/remove_from_library.rs
+++ b/src/unit_tests/ctx/remove_from_library.rs
@@ -16,7 +16,7 @@ use stremio_derive::Model;
 
 #[test]
 fn actionctx_removefromlibrary() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -148,7 +148,7 @@ fn actionctx_removefromlibrary() {
 
 #[test]
 fn actionctx_removefromlibrary_not_added() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/rewind_library_item.rs
+++ b/src/unit_tests/ctx/rewind_library_item.rs
@@ -16,7 +16,7 @@ use stremio_derive::Model;
 
 #[test]
 fn actionctx_rewindlibraryitem() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -154,7 +154,7 @@ fn actionctx_rewindlibraryitem() {
 
 #[test]
 fn actionctx_rewindlibraryitem_not_added() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/sync_library_with_api.rs
+++ b/src/unit_tests/ctx/sync_library_with_api.rs
@@ -19,7 +19,7 @@ use stremio_derive::Model;
 
 #[test]
 fn actionctx_synclibrarywithapi() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -40,7 +40,7 @@ fn actionctx_synclibrarywithapi() {
 
 #[test]
 fn actionctx_synclibrarywithapi_with_user() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -366,7 +366,7 @@ fn actionctx_synclibrarywithapi_with_user() {
 
 #[test]
 fn actionctx_synclibrarywithapi_with_user_empty_library() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/uninstall_addon.rs
+++ b/src/unit_tests/ctx/uninstall_addon.rs
@@ -17,7 +17,7 @@ use url::Url;
 
 #[test]
 fn actionctx_uninstalladdon() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -91,7 +91,7 @@ fn actionctx_uninstalladdon() {
 
 #[test]
 fn actionctx_uninstalladdon_with_user() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -212,7 +212,7 @@ fn actionctx_uninstalladdon_with_user() {
 
 #[test]
 fn actionctx_uninstalladdon_protected() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -287,7 +287,7 @@ fn actionctx_uninstalladdon_protected() {
 
 #[test]
 fn actionctx_uninstalladdon_not_installed() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/update_settings.rs
+++ b/src/unit_tests/ctx/update_settings.rs
@@ -8,7 +8,7 @@ use stremio_derive::Model;
 
 #[test]
 fn actionctx_updatesettings() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -49,7 +49,7 @@ fn actionctx_updatesettings() {
 
 #[test]
 fn actionctx_updatesettings_not_changed() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/ctx/upgrade_addon.rs
+++ b/src/unit_tests/ctx/upgrade_addon.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 #[test]
 fn actionctx_addon_upgrade() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,
@@ -118,7 +118,7 @@ fn actionctx_addon_upgrade() {
 
 #[test]
 fn actionctx_addon_upgrade_fail_due_to_different_url() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/data_export.rs
+++ b/src/unit_tests/data_export.rs
@@ -72,13 +72,13 @@ fn data_export_with_user() {
         events[0]
             .downcast_ref::<RuntimeEvent<TestEnv, TestModel>>()
             .unwrap(),
-        RuntimeEvent::NewState(fields) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::DataExport
+        RuntimeEvent::NewState(fields, _) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::DataExport
     );
     assert_matches!(
         events[1]
             .downcast_ref::<RuntimeEvent<TestEnv, TestModel>>()
             .unwrap(),
-        RuntimeEvent::NewState(fields) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::DataExport
+        RuntimeEvent::NewState(fields, _) if fields.len() == 1 && *fields.first().unwrap() == TestModelField::DataExport
     );
     let states = STATES.read().unwrap();
     let states = states

--- a/src/unit_tests/env.rs
+++ b/src/unit_tests/env.rs
@@ -77,17 +77,6 @@ impl TestEnv {
         runnable: F,
     ) {
         tokio_current_thread::block_on_all(future::lazy(|_| {
-            TestEnv::exec_concurrent(rx.for_each(enclose!((runtime) move |event| {
-                if let RuntimeEvent::NewState(_) = event {
-                    let runtime = runtime.read().expect("runtime read failed");
-                    let state = runtime.model().expect("model read failed");
-                    let mut states = STATES.write().expect("states write failed");
-                    states.push(Box::new(state.to_owned()) as Box<dyn Any + Send + Sync>);
-                };
-                let mut events = EVENTS.write().expect("events write failed");
-                events.push(Box::new(event) as Box<dyn Any + Send + Sync>);
-                future::ready(())
-            })));
             {
                 let runtime = runtime.read().expect("runtime read failed");
                 let state = runtime.model().expect("model read failed");
@@ -95,11 +84,22 @@ impl TestEnv {
                 states.push(Box::new(state.to_owned()) as Box<dyn Any + Send + Sync>);
             }
             runnable();
+        }));
+        tokio_current_thread::block_on_all(future::lazy(|_| {
+            TestEnv::exec_concurrent(rx.for_each(move |event| {
+                if let RuntimeEvent::NewState(_, state) = &event {
+                    let mut states = STATES.write().expect("states write failed");
+                    states.push(Box::new(state.to_owned()) as Box<dyn Any + Send + Sync>);
+                };
+                let mut events = EVENTS.write().expect("events write failed");
+                events.push(Box::new(event) as Box<dyn Any + Send + Sync>);
+                future::ready(())
+            }));
             TestEnv::exec_concurrent(enclose!((runtime) async move {
                 let mut runtime = runtime.write().expect("runtime read failed");
                 runtime.close().await.unwrap();
             }));
-        }))
+        }));
     }
 }
 

--- a/src/unit_tests/link.rs
+++ b/src/unit_tests/link.rs
@@ -11,7 +11,7 @@ use stremio_derive::Model;
 
 #[test]
 fn create_link_code() {
-    #[derive(Model, Default)]
+    #[derive(Model, Clone, Default)]
     #[model(TestEnv)]
     struct TestModel {
         ctx: Ctx,

--- a/src/unit_tests/meta_details/mod.rs
+++ b/src/unit_tests/meta_details/mod.rs
@@ -1,0 +1,1 @@
+mod override_selected;

--- a/src/unit_tests/meta_details/override_selected.rs
+++ b/src/unit_tests/meta_details/override_selected.rs
@@ -1,0 +1,328 @@
+use crate::constants::{CINEMETA_URL, META_RESOURCE_NAME, OFFICIAL_ADDONS, STREAM_RESOURCE_NAME};
+use crate::models::ctx::Ctx;
+use crate::models::meta_details::{MetaDetails, Selected};
+use crate::runtime::msg::{Action, ActionLoad};
+use crate::runtime::{EnvFutureExt, Runtime, RuntimeAction, TryEnvFuture};
+use crate::types::addon::{ResourcePath, ResourceResponse};
+use crate::types::profile::Profile;
+use crate::types::resource::{MetaItem, MetaItemBehaviorHints, MetaItemPreview, Video};
+use crate::unit_tests::{default_fetch_handler, Request, TestEnv, FETCH_HANDLER, STATES};
+use assert_matches::assert_matches;
+use enclose::enclose;
+use futures::future;
+use std::any::Any;
+use std::sync::{Arc, RwLock};
+use stremio_derive::Model;
+
+#[test]
+fn override_selected_default_video_id() {
+    #[derive(Model, Default, Clone, Debug)]
+    #[model(TestEnv)]
+    struct TestModel {
+        ctx: Ctx,
+        meta_details: MetaDetails,
+    }
+    fn fetch_handler(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+        match request {
+            Request { url, .. } if url == "https://v3-cinemeta.strem.io/meta/movie/tt1.json" => {
+                future::ok(Box::new(ResourceResponse::Meta {
+                    meta: MetaItem {
+                        preview: MetaItemPreview {
+                            id: "tt1".to_owned(),
+                            r#type: "movie".to_owned(),
+                            behavior_hints: MetaItemBehaviorHints {
+                                default_video_id: Some("_tt1".to_owned()),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        },
+                        videos: vec![],
+                    },
+                }) as Box<dyn Any + Send>)
+                .boxed_env()
+            }
+            Request { url, .. }
+                if url == "https://v3-cinemeta.strem.io//stream/movie/_tt1.json" =>
+            {
+                future::ok(
+                    Box::new(ResourceResponse::Streams { streams: vec![] }) as Box<dyn Any + Send>
+                )
+                .boxed_env()
+            }
+            _ => default_fetch_handler(request),
+        }
+    }
+    let _env_mutex = TestEnv::reset();
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+    let (runtime, rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx {
+                profile: Profile {
+                    addons: OFFICIAL_ADDONS
+                        .iter()
+                        .filter(|addon| addon.transport_url == *CINEMETA_URL)
+                        .cloned()
+                        .collect(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            meta_details: Default::default(),
+        },
+        vec![],
+        1000,
+    );
+    let runtime = Arc::new(RwLock::new(runtime));
+    TestEnv::run_with_runtime(
+        rx,
+        runtime.clone(),
+        enclose!((runtime) move || {
+            let runtime = runtime.read().unwrap();
+            runtime.dispatch(RuntimeAction {
+                field: None,
+                action: Action::Load(ActionLoad::MetaDetails(Selected {
+                    meta_path: ResourcePath {
+                        resource: META_RESOURCE_NAME.to_owned(),
+                        r#type: "movie".to_owned(),
+                        id: "tt1".to_owned(),
+                        extra: vec![]
+                    },
+                    stream_path: None
+                })),
+            });
+        }),
+    );
+    let states = STATES.read().unwrap();
+    let states = states
+        .iter()
+        .map(|state| state.downcast_ref::<TestModel>().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(states.len(), 3);
+    assert_matches!(states[0].meta_details.selected, None);
+    assert_matches!(
+        states[1].meta_details.selected,
+        Some(Selected {
+            stream_path: None,
+            ..
+        })
+    );
+    assert_matches!(
+        &states[2].meta_details.selected,
+        Some(Selected {
+            stream_path: Some(ResourcePath {
+                resource,
+                r#type,
+                id,
+                ..
+            }),
+            ..
+        }) if id == "_tt1" && r#type == "movie" && resource == STREAM_RESOURCE_NAME
+    );
+}
+
+#[test]
+fn override_selected_only_video_id() {
+    #[derive(Model, Default, Clone, Debug)]
+    #[model(TestEnv)]
+    struct TestModel {
+        ctx: Ctx,
+        meta_details: MetaDetails,
+    }
+    fn fetch_handler(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+        match request {
+            Request { url, .. } if url == "https://v3-cinemeta.strem.io/meta/movie/tt1.json" => {
+                future::ok(Box::new(ResourceResponse::Meta {
+                    meta: MetaItem {
+                        preview: MetaItemPreview {
+                            id: "tt1".to_owned(),
+                            r#type: "movie".to_owned(),
+                            ..Default::default()
+                        },
+                        videos: vec![Video {
+                            id: "_tt1".to_owned(),
+                            ..Default::default()
+                        }],
+                    },
+                }) as Box<dyn Any + Send>)
+                .boxed_env()
+            }
+            Request { url, .. }
+                if url == "https://v3-cinemeta.strem.io//stream/movie/_tt1.json" =>
+            {
+                future::ok(
+                    Box::new(ResourceResponse::Streams { streams: vec![] }) as Box<dyn Any + Send>
+                )
+                .boxed_env()
+            }
+            _ => default_fetch_handler(request),
+        }
+    }
+    let _env_mutex = TestEnv::reset();
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+    let (runtime, rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx {
+                profile: Profile {
+                    addons: OFFICIAL_ADDONS
+                        .iter()
+                        .filter(|addon| addon.transport_url == *CINEMETA_URL)
+                        .cloned()
+                        .collect(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            meta_details: Default::default(),
+        },
+        vec![],
+        1000,
+    );
+    let runtime = Arc::new(RwLock::new(runtime));
+    TestEnv::run_with_runtime(
+        rx,
+        runtime.clone(),
+        enclose!((runtime) move || {
+            let runtime = runtime.read().unwrap();
+            runtime.dispatch(RuntimeAction {
+                field: None,
+                action: Action::Load(ActionLoad::MetaDetails(Selected {
+                    meta_path: ResourcePath {
+                        resource: META_RESOURCE_NAME.to_owned(),
+                        r#type: "movie".to_owned(),
+                        id: "tt1".to_owned(),
+                        extra: vec![]
+                    },
+                    stream_path: None
+                })),
+            });
+        }),
+    );
+    let states = STATES.read().unwrap();
+    let states = states
+        .iter()
+        .map(|state| state.downcast_ref::<TestModel>().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(states.len(), 3);
+    assert_matches!(states[0].meta_details.selected, None);
+    assert_matches!(
+        states[1].meta_details.selected,
+        Some(Selected {
+            stream_path: None,
+            ..
+        })
+    );
+    assert_matches!(
+        &states[2].meta_details.selected,
+        Some(Selected {
+            stream_path: Some(ResourcePath {
+                resource,
+                r#type,
+                id,
+                ..
+            }),
+            ..
+        }) if id == "_tt1" && r#type == "movie" && resource == STREAM_RESOURCE_NAME
+    );
+}
+
+#[test]
+fn override_selected_meta_id() {
+    #[derive(Model, Default, Clone, Debug)]
+    #[model(TestEnv)]
+    struct TestModel {
+        ctx: Ctx,
+        meta_details: MetaDetails,
+    }
+    fn fetch_handler(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+        match request {
+            Request { url, .. } if url == "https://v3-cinemeta.strem.io/meta/movie/tt1.json" => {
+                future::ok(Box::new(ResourceResponse::Meta {
+                    meta: MetaItem {
+                        preview: MetaItemPreview {
+                            id: "tt1".to_owned(),
+                            r#type: "movie".to_owned(),
+                            ..Default::default()
+                        },
+                        videos: vec![],
+                    },
+                }) as Box<dyn Any + Send>)
+                .boxed_env()
+            }
+            Request { url, .. }
+                if url == "https://v3-cinemeta.strem.io//stream/movie/_tt1.json" =>
+            {
+                future::ok(
+                    Box::new(ResourceResponse::Streams { streams: vec![] }) as Box<dyn Any + Send>
+                )
+                .boxed_env()
+            }
+            _ => default_fetch_handler(request),
+        }
+    }
+    let _env_mutex = TestEnv::reset();
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+    let (runtime, rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx {
+                profile: Profile {
+                    addons: OFFICIAL_ADDONS
+                        .iter()
+                        .filter(|addon| addon.transport_url == *CINEMETA_URL)
+                        .cloned()
+                        .collect(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            meta_details: Default::default(),
+        },
+        vec![],
+        1000,
+    );
+    let runtime = Arc::new(RwLock::new(runtime));
+    TestEnv::run_with_runtime(
+        rx,
+        runtime.clone(),
+        enclose!((runtime) move || {
+            let runtime = runtime.read().unwrap();
+            runtime.dispatch(RuntimeAction {
+                field: None,
+                action: Action::Load(ActionLoad::MetaDetails(Selected {
+                    meta_path: ResourcePath {
+                        resource: META_RESOURCE_NAME.to_owned(),
+                        r#type: "movie".to_owned(),
+                        id: "tt1".to_owned(),
+                        extra: vec![]
+                    },
+                    stream_path: None
+                })),
+            });
+        }),
+    );
+    let states = STATES.read().unwrap();
+    let states = states
+        .iter()
+        .map(|state| state.downcast_ref::<TestModel>().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(states.len(), 3);
+    assert_matches!(states[0].meta_details.selected, None);
+    assert_matches!(
+        states[1].meta_details.selected,
+        Some(Selected {
+            stream_path: None,
+            ..
+        })
+    );
+    assert_matches!(
+        &states[2].meta_details.selected,
+        Some(Selected {
+            stream_path: Some(ResourcePath {
+                resource,
+                r#type,
+                id,
+                ..
+            }),
+            ..
+        }) if id == "tt1" && r#type == "movie" && resource == STREAM_RESOURCE_NAME
+    );
+}

--- a/src/unit_tests/meta_details/override_selected.rs
+++ b/src/unit_tests/meta_details/override_selected.rs
@@ -41,14 +41,6 @@ fn override_selected_default_video_id() {
                 }) as Box<dyn Any + Send>)
                 .boxed_env()
             }
-            Request { url, .. }
-                if url == "https://v3-cinemeta.strem.io//stream/movie/_tt1.json" =>
-            {
-                future::ok(
-                    Box::new(ResourceResponse::Streams { streams: vec![] }) as Box<dyn Any + Send>
-                )
-                .boxed_env()
-            }
             _ => default_fetch_handler(request),
         }
     }
@@ -146,14 +138,6 @@ fn override_selected_only_video_id() {
                 }) as Box<dyn Any + Send>)
                 .boxed_env()
             }
-            Request { url, .. }
-                if url == "https://v3-cinemeta.strem.io//stream/movie/_tt1.json" =>
-            {
-                future::ok(
-                    Box::new(ResourceResponse::Streams { streams: vec![] }) as Box<dyn Any + Send>
-                )
-                .boxed_env()
-            }
             _ => default_fetch_handler(request),
         }
     }
@@ -246,14 +230,6 @@ fn override_selected_meta_id() {
                         videos: vec![],
                     },
                 }) as Box<dyn Any + Send>)
-                .boxed_env()
-            }
-            Request { url, .. }
-                if url == "https://v3-cinemeta.strem.io//stream/movie/_tt1.json" =>
-            {
-                future::ok(
-                    Box::new(ResourceResponse::Streams { streams: vec![] }) as Box<dyn Any + Send>
-                )
                 .boxed_env()
             }
             _ => default_fetch_handler(request),

--- a/src/unit_tests/mod.rs
+++ b/src/unit_tests/mod.rs
@@ -3,9 +3,9 @@ pub use env::*;
 
 mod catalog_with_filters;
 mod ctx;
-mod data_export;
+mod deep_links;
+mod meta_details;
 mod serde;
 
+mod data_export;
 mod link;
-
-mod deep_links;


### PR DESCRIPTION
Override meta details selected based on viable meta if
1. meta_item has single video, use video id
2. meta_item has 0 videos and default video id, use default video id
3. meta_item has 0 videos and is a movie, use meta item id

Viable meta item is the first item in MetaDetails.meta_items that is not in Err state.

This pr does not require changes in core-web or web, not so sure about the tv app.

- [x] write unit tests
- [x] derive Clone for all models #474 
