### PR TITLE
fix: rename fields of ActionSearch::Search

### DIFF
--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -131,6 +131,7 @@ pub enum ActionLoad {
 #[serde(tag = "action", content = "args")]
 pub enum ActionSearch {
     /// Request for Search queries
+    #[serde(rename_all = "camelCase")]
     Search {
         search_query: String,
         max_results: usize,


### PR DESCRIPTION
Continuation of #482 to keep the action field names consistent.