### PR TITLE
Resolve stream proxied streaming link when url has request headers

### DIFF
--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -185,7 +185,7 @@ impl From<(&LibraryItem, Option<&StreamsItem>, Option<&Url>, &Settings)> for Lib
                         utf8_percent_encode(video_id, URI_COMPONENT_ENCODE_SET)
                     )
                 }),
-            // We have the steam so use the same logic as in StreamDeepLinks
+            // We have the stream so use the same logic as in StreamDeepLinks
             player: streams_item.map(|streams_item| match streams_item.stream.encode() {
                 Ok(encoded_stream) => format!(
                     "stremio:///player/{}/{}/{}/{}/{}/{}",
@@ -204,7 +204,7 @@ impl From<(&LibraryItem, Option<&StreamsItem>, Option<&Url>, &Settings)> for Lib
                 ),
                 Err(error) => ErrorLink::from(error).into(),
             }),
-            // We have the steams bucket item so use the same logic as in StreamDeepLinks
+            // We have the streams bucket item so use the same logic as in StreamDeepLinks
             external_player: streams_item.map(|item| {
                 ExternalPlayerLink::from((&item.stream, streaming_server_url, settings))
             }),

--- a/src/types/resource/stream.rs
+++ b/src/types/resource/stream.rs
@@ -14,7 +14,7 @@ use serde_with::{serde_as, DefaultOnNull};
 use std::collections::HashMap;
 use std::io::Write;
 use stremio_serde_hex::{SerHex, Strict};
-use url::Url;
+use url::{form_urlencoded, Url};
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -136,7 +136,38 @@ impl Stream {
     }
     pub fn streaming_url(&self, streaming_server_url: Option<&Url>) -> Option<String> {
         match (&self.source, streaming_server_url) {
-            (StreamSource::Url { url }, _) if url.scheme() != "magnet" => Some(url.to_string()),
+            (StreamSource::Url { url }, _) if url.scheme() != "magnet" => {
+                match (streaming_server_url, &self.behavior_hints.proxy_headers) {
+                    (
+                        Some(streaming_server_url),
+                        Some(StreamProxyHeaders { request, response }),
+                    ) => {
+                        let mut streaming_url = streaming_server_url.to_owned();
+                        let mut proxy_query = form_urlencoded::Serializer::new(String::new());
+                        let origin = format!("{}://{}", url.scheme(), url.authority());
+                        proxy_query.append_pair("d", origin.as_str());
+                        proxy_query.extend_pairs(
+                            request
+                                .iter()
+                                .map(|header| ("h", format!("{}:{}", header.0, header.1))),
+                        );
+                        proxy_query.extend_pairs(
+                            response
+                                .iter()
+                                .map(|header| ("r", format!("{}:{}", header.0, header.1))),
+                        );
+                        streaming_url
+                            .path_segments_mut()
+                            .ok()?
+                            .push("proxy")
+                            .push(proxy_query.finish().as_str())
+                            .push(&url.path()[1..]);
+                        streaming_url.set_query(url.query());
+                        Some(streaming_url.to_string())
+                    }
+                    _ => Some(url.to_string()),
+                }
+            }
             (
                 StreamSource::Torrent {
                     info_hash,
@@ -149,9 +180,9 @@ impl Stream {
                 match url.path_segments_mut() {
                     Ok(mut path) => {
                         path.push(&hex::encode(info_hash));
-                        if let Some(file_idx) = file_idx {
-                            path.push(&file_idx.to_string());
-                        }
+                        path.push(
+                            &file_idx.map_or_else(|| "-1".to_string(), |idx| idx.to_string()),
+                        );
                     }
                     _ => return None,
                 };

--- a/src/types/resource/stream.rs
+++ b/src/types/resource/stream.rs
@@ -180,6 +180,8 @@ impl Stream {
                 match url.path_segments_mut() {
                     Ok(mut path) => {
                         path.push(&hex::encode(info_hash));
+                        // When fileIndex is not provided use -1, which will tell the
+                        // streaming server to choose the file with the largest size from the torrent
                         path.push(
                             &file_idx.map_or_else(|| "-1".to_string(), |idx| idx.to_string()),
                         );


### PR DESCRIPTION
Also streaming server now support `fileIndex=-1` when no index is available and will resolved the biggest file.