### PR TITLE
Detach video params from selected

### DIFF
--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -810,7 +810,7 @@ fn subtitles_update<E: Env + 'static>(
                         ),
                     ..subtitles_path.to_owned()
                 }),
-                &addons,
+                addons,
             ),
         ),
         _ => eq_update(subtitles, vec![]),

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -164,6 +164,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     },
                     _ => eq_update(&mut self.meta_item, None),
                 };
+                let video_params_effects = eq_update(&mut self.video_params, None);
                 let subtitles_effects = subtitles_update::<E>(
                     &mut self.subtitles,
                     &self.selected,
@@ -232,6 +233,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     .join(update_streams_effects)
                     .join(selected_effects)
                     .join(meta_item_effects)
+                    .join(video_params_effects)
                     .join(subtitles_effects)
                     .join(next_video_effects)
                     .join(next_streams_effects)

--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -12,7 +12,7 @@ use crate::{
         library_by_type::Selected as LibraryByTypeSelected,
         library_with_filters::Selected as LibraryWithFiltersSelected,
         meta_details::Selected as MetaDetailsSelected,
-        player::Selected as PlayerSelected,
+        player::{Selected as PlayerSelected, VideoParams},
         streaming_server::{
             Settings as StreamingServerSettings,
             StatisticsRequest as StreamingServerStatisticsRequest,
@@ -126,6 +126,10 @@ pub enum ActionLink {
 #[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum ActionPlayer {
+    #[serde(rename_all = "camelCase")]
+    VideoParamsChanged {
+        video_params: Option<VideoParams>,
+    },
     TimeChanged {
         time: u64,
         duration: u64,

--- a/src/unit_tests/ctx/notifications/update_notifications.rs
+++ b/src/unit_tests/ctx/notifications/update_notifications.rs
@@ -316,7 +316,6 @@ fn test_pull_notifications_and_play_in_player() {
                     },
                 }),
                 subtitles_path: None,
-                video_params: None,
             }))),
         });
         runtime.dispatch(RuntimeAction {


### PR DESCRIPTION
While integrating the the latest stremio-video into stremio-web, in order to start sending videoParams to subtitles addons, i found an issue with how stremio-core and stremio-web worked together. 
1. In stremio-web we reload stremio-video on each change of player.selected.
2. Reloading stremio-video results in fetching the videoParams from the stremio-server.
3. Updating the videoParams prop from stremio-video causes a new Load action for the Player model to be dispatched.
4. Dispatching a new Load action to the Player model causes player.selected to change.
5. And it all ends in an infinete loop.

The only way to integrate all parts together is by detaching the videoParams from the player's selected prop. (or a massive refactor down to the useCoreModel hook and potentially every route of stremio-web)

This change is a breaking change for stremio-android-tv. It needs to send this new PlayerAction::VideoParamsUpdated instead of new Load action once video params are ready. @TheBeastLT Does that look like a simple change or it will cause massive refactor on your side?

The functionality can be tested in stremio-web gh pages on this url: https://stremio.github.io/stremio-web/update-stremio-video/#/player/eJwVysENgDAIAMBdGKB8fHUbrAQbSyAFjYlxd+O974FzDqiwZ3pUxEibJFzETAaT9yjNFOWi1W5U3jphkPrg+G87ivoC7wel8Bou/https%3A%2F%2Fv3-cinemeta.strem.io%2Fmanifest.json/https%3A%2F%2Fv3-cinemeta.strem.io%2Fmanifest.json/movie/tt420/tt420
which load some stock video with an arbitrary tt prefixed id
In the network tab you can see the opensubtitles request with the correct params.

...

_The PR is based on [this commit](https://github.com/Stremio/stremio-core/commit/1259c0c2963417bb54077f570889073278368783) because there are some changes in development branch which are not compatible with core-web's deveopment branch._

_CI fails for some unrelated reason_
