### PR TITLE
feat: MetaDetails - guess streams only when a flag is present

### DIFF
--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -1,26 +1,38 @@
-use crate::constants::{LIBRARY_COLLECTION_NAME, META_RESOURCE_NAME, STREAM_RESOURCE_NAME};
-use crate::models::common::{
-    eq_update, resources_update, resources_update_with_vector_content, Loadable, ResourceLoadable,
-    ResourcesAction,
-};
-use crate::models::ctx::Ctx;
-use crate::runtime::msg::{Action, ActionLoad, ActionMetaDetails, Internal, Msg};
-use crate::runtime::{Effects, Env, UpdateWithCtx};
-use crate::types::addon::{AggrRequest, ResourcePath, ResourceRequest};
-use crate::types::api::{DatastoreCommand, DatastoreRequest};
-use crate::types::library::{LibraryBucket, LibraryItem};
-use crate::types::profile::Profile;
-use crate::types::resource::{MetaItem, Stream};
+use std::{borrow::Cow, marker::PhantomData};
+
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
-use std::marker::PhantomData;
+
 use stremio_watched_bitfield::WatchedBitField;
+
+use crate::{
+    constants::{LIBRARY_COLLECTION_NAME, META_RESOURCE_NAME, STREAM_RESOURCE_NAME},
+    models::{
+        common::{
+            eq_update, resources_update, resources_update_with_vector_content, Loadable,
+            ResourceLoadable, ResourcesAction,
+        },
+        ctx::Ctx,
+    },
+    runtime::{
+        msg::{Action, ActionLoad, ActionMetaDetails, Internal, Msg},
+        Effects, Env, UpdateWithCtx,
+    },
+    types::{
+        addon::{AggrRequest, ResourcePath, ResourceRequest},
+        api::{DatastoreCommand, DatastoreRequest},
+        library::{LibraryBucket, LibraryItem},
+        profile::Profile,
+        resource::{MetaItem, Stream},
+    },
+};
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Selected {
     pub meta_path: ResourcePath,
     pub stream_path: Option<ResourcePath>,
+    #[serde(default)]
+    pub stream_override: bool,
 }
 
 #[derive(Default, Serialize, Clone, Debug)]
@@ -214,6 +226,19 @@ fn library_item_sync(library_item: &Option<LibraryItem>, profile: &Profile) -> E
     }
 }
 
+/// If `Selected::stream_override` is `true` then we will override the selected stream
+/// no matter if it's set (`Some`) or not (`None`).
+///
+/// How we override the stream:
+///
+/// 1. We find the first `MetaItem` that's successfully loaded from the addons.
+/// 2. Selecting the video id for the stream request:
+/// 2.1 If there's a `MetaItem.preview.behavior_hints.default_video_id`
+/// we use it for the request
+/// 2.2 If there's no `default_video_id` and no `MetaItem.videos` returned by the addon,
+/// we use the `MetaItem.preview.id`
+///
+/// If we haven't found a suitable `video_id`, then we do not override the `Selected::stream_path`.
 fn selected_override_update(
     selected: &mut Option<Selected>,
     meta_items: &[ResourceLoadable<MetaItem>],
@@ -221,19 +246,20 @@ fn selected_override_update(
     let meta_path = match &selected {
         Some(Selected {
             meta_path,
-            stream_path: None,
+            stream_override: true,
+            // we do not check the stream_path because we are forcefully overriding it
+            // and it's value is not taken into account
+            ..
         }) => meta_path,
         _ => return Effects::default(),
     };
     let meta_item = match meta_items
         .iter()
         .find_map(|meta_item| match &meta_item.content {
-            Some(Loadable::Ready(meta_item)) => Some(Some(meta_item)),
-            Some(Loadable::Loading) => Some(None),
+            Some(Loadable::Ready(meta_item)) => Some(meta_item),
+            Some(Loadable::Loading) => None,
             _ => None,
-        })
-        .flatten()
-    {
+        }) {
         Some(meta_item) => meta_item,
         _ => return Effects::default(),
     };
@@ -255,6 +281,9 @@ fn selected_override_update(
                 id: video_id,
                 extra: vec![],
             }),
+            // we must set the stream_override to false after we've overridden it
+            // to make it consistent
+            stream_override: false,
         }),
     )
 }

--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -228,7 +228,7 @@ fn library_item_sync(library_item: &Option<LibraryItem>, profile: &Profile) -> E
     }
 }
 
-/// If `Selected::stream_override` is `true` then we will override the selected stream
+/// If `Selected::guess_stream` is `true` then we will override the selected stream
 /// no matter if it's set (`Some`) or not (`None`).
 ///
 /// How we override the stream:
@@ -282,7 +282,7 @@ fn selected_guess_stream_update(
                 id: video_id,
                 extra: vec![],
             }),
-            // we must set the stream_override to false after we've overridden it
+            // we must set the `guess_stream` to `false` after we've overridden it
             // to make it consistent
             guess_stream: false,
         }),

--- a/src/unit_tests/meta_details/override_selected.rs
+++ b/src/unit_tests/meta_details/override_selected.rs
@@ -79,7 +79,8 @@ fn override_selected_default_video_id() {
                         id: "tt1".to_owned(),
                         extra: vec![]
                     },
-                    stream_path: None
+                    stream_path: None,
+                    stream_override: true,
                 })),
             });
         }),
@@ -173,7 +174,8 @@ fn override_selected_meta_id() {
                         id: "tt1".to_owned(),
                         extra: vec![]
                     },
-                    stream_path: None
+                    stream_path: None,
+                    stream_override: true,
                 })),
             });
         }),

--- a/src/unit_tests/meta_details/override_selected.rs
+++ b/src/unit_tests/meta_details/override_selected.rs
@@ -80,7 +80,7 @@ fn override_selected_default_video_id() {
                         extra: vec![]
                     },
                     stream_path: None,
-                    stream_override: true,
+                    guess_stream: true,
                 })),
             });
         }),
@@ -175,7 +175,7 @@ fn override_selected_meta_id() {
                         extra: vec![]
                     },
                     stream_path: None,
-                    stream_override: true,
+                    guess_stream: true,
                 })),
             });
         }),


### PR DESCRIPTION
This feature allows you to load the MeteDetails without loading streams.
Previous feature allowed the guessing of the streams if a stream_path was not provided - see #474, but there are cases in the apps where we load the `MetaDetails` but we don't actually want to load the streams as we only show a small modal with just a few things from the MetaDetails like the Trailer.

We now have 4 code cases:
1. `stream_path: Some` and we have `guess_stream: false` - loads the stream from the provided path
2. `stream_path: Some` and `guess_stream: true` - loads the stream from the provided path ignoring the `guess_stream: true`
3. `stream_path: None` and `guess_stream: true` - guesses the `stream_path` using the first successfully loaded `MetaItem`
4. `stream_path: None` and `guess_stream: false` - no streams will be loaded for the `MetaDetails`