### PR TITLE
fix: server's stats.json response for SwarmCap

### DIFF
--- a/src/types/streaming_server/statistics.rs
+++ b/src/types/streaming_server/statistics.rs
@@ -28,7 +28,7 @@ pub struct PeerSearch {
 #[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SwarmCap {
-    pub max_speed: u64,
+    pub max_speed: f64,
     pub min_peers: u64,
 }
 


### PR DESCRIPTION
I was getting an error in core after debugging why the statistics for a stream don't show up in stremio-web.
> INFO /stremio/core/src/models/streaming_server.rs:593 result for statistics: Err(Fetch("opts.swarmCap.maxSpeed: invalid type: floating point `1677721.6`, expected u64 at line 1 column 5274")) [stremio_core_web.js:709:27](webpack-internal:///../core-web/stremio_core_web.js)

This fix changes maxSpeed to be a floating point number.