### PR TITLE
Add IINA & mpv as external players

### DIFF
--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -112,6 +112,14 @@ impl From<(&Stream, Option<&Url>, &Settings)> for ExternalPlayerLink {
                         ios: Some(format!("infuse://x-callback-url/play?url={url}")),
                        ..Default::default()
                     }),
+                    "iina" => Some(OpenPlayerLink {
+                        macos: Some(format!("iina://weblink?url={url}")),
+                       ..Default::default()
+                    }),
+                    "mpv" => Some(OpenPlayerLink {
+                        macos: Some(format!("mpv://{url}")),
+                       ..Default::default()
+                    }),
                     _ => None,
                 },
                 None => None,


### PR DESCRIPTION
[mpv URL handler is only "default" on MacOS](https://github.com/mpv-player/mpv/blob/master/TOOLS/osxbundle/mpv.app/Contents/Info.plist#L200-L209), hence why it is only for MacOS and not also Windows & Linux.