### PR TITLE
fix: StreamingServer statistics response `null`

### DIFF
--- a/src/models/streaming_server.rs
+++ b/src/models/streaming_server.rs
@@ -180,6 +180,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for StreamingServer {
                 let selected_effects =
                     eq_update(&mut self.selected.statistics, Some(request.to_owned()));
                 let statistics_effects = eq_update(&mut self.statistics, Some(Loadable::Loading));
+
                 Effects::one(get_torrent_statistics::<E>(
                     &self.selected.transport_url,
                     request,
@@ -589,8 +590,11 @@ fn get_torrent_statistics<E: Env + 'static>(url: &Url, request: &StatisticsReque
         .header(http::header::CONTENT_TYPE, "application/json")
         .body(())
         .expect("request builder failed");
+
+    // It's happening when the engine is destroyed for inactivity:
+    // If it was downloaded to 100% and that the stream is paused, then played,
+    // it will create a new engine and return the correct stats
     EffectFuture::Concurrent(
-        // `null`` can be returned when the stream has been loaded 100%
         E::fetch::<_, Option<Statistics>>(request)
             .map(enclose!((url) move |result|
                 Msg::Internal(Internal::StreamingServerStatisticsResult((url, statistics_request), result))

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -106,7 +106,10 @@ pub enum Internal {
     ///
     /// Server will return None (or `null`) in response for [`Statistics`]`,
     /// when stream has been fully loaded up to 100%
-    StreamingServerStatisticsResult((Url, StatisticsRequest), Result<Option<Statistics>, EnvError>),
+    StreamingServerStatisticsResult(
+        (Url, StatisticsRequest),
+        Result<Option<Statistics>, EnvError>,
+    ),
     /// Result for fetching resource from addons.
     ResourceRequestResult(ResourceRequest, Box<Result<ResourceResponse, EnvError>>),
     /// Result for fetching manifest from addon.

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -100,10 +100,13 @@ pub enum Internal {
     StreamingServerUpdateSettingsResult(Url, Result<(), EnvError>),
     /// Result for creating a torrent.
     StreamingServerCreateTorrentResult(String, Result<(), EnvError>),
-    // Result for playing on device.
+    /// Result for playing on device.
     StreamingServerPlayOnDeviceResult(String, Result<(), EnvError>),
-    // Result for streaming server statistics.
-    StreamingServerStatisticsResult((Url, StatisticsRequest), Result<Statistics, EnvError>),
+    /// Result for streaming server statistics.
+    ///
+    /// Server will return None (or `null`) in response for [`Statistics`]`,
+    /// when stream has been fully loaded up to 100%
+    StreamingServerStatisticsResult((Url, StatisticsRequest), Result<Option<Statistics>, EnvError>),
     /// Result for fetching resource from addons.
     ResourceRequestResult(ResourceRequest, Box<Result<ResourceResponse, EnvError>>),
     /// Result for fetching manifest from addon.


### PR DESCRIPTION
Resolves #573
Fix the issue where the server returns a `null` json response for the `stats.json`.
Up until now it was throwing an error on deserialization