### PR TITLE
Feat/limit pull notifs last videos requests to every 6h

### DIFF
--- a/src/unit_tests/ctx/notifications/update_notifications.rs
+++ b/src/unit_tests/ctx/notifications/update_notifications.rs
@@ -371,7 +371,7 @@ fn test_pull_notifications_test_cases() {
                 return future::ok(Box::new(result.to_owned()) as Box<dyn Any + Send>).boxed_env();
             }
 
-            return default_fetch_handler(request);
+            default_fetch_handler(request)
         });
         *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
 

--- a/src/unit_tests/streaming_server/remote_endpoint.rs
+++ b/src/unit_tests/streaming_server/remote_endpoint.rs
@@ -56,7 +56,7 @@ fn remote_endpoint() {
                 if method == "GET" && url == "http://127.0.0.1:11470/settings" =>
             {
                 future::ok(Box::new(SettingsResponse {
-                    base_url: Url::parse(&STREAMING_SERVER_URL.to_string()).unwrap(),
+                    base_url: Url::parse(STREAMING_SERVER_URL).unwrap(),
                     values: STREAMING_SERVER_SETTINGS,
                 }) as Box<dyn Any + Send>)
                 .boxed_env()
@@ -68,7 +68,7 @@ fn remote_endpoint() {
                     .boxed_env()
             }
             Request { url, .. } if url == "http://127.0.0.1:11470/casting" => {
-                future::ok(Box::new(Vec::<PlaybackDevice>::new()) as Box<dyn Any + Send>)
+                future::ok(Box::<Vec<PlaybackDevice>>::default() as Box<dyn Any + Send>)
                     .boxed_env()
             }
             Request { url, .. } if url == "http://127.0.0.1:11470/network-info" => {

--- a/src/unit_tests/streaming_server/remote_endpoint.rs
+++ b/src/unit_tests/streaming_server/remote_endpoint.rs
@@ -68,8 +68,7 @@ fn remote_endpoint() {
                     .boxed_env()
             }
             Request { url, .. } if url == "http://127.0.0.1:11470/casting" => {
-                future::ok(Box::<Vec<PlaybackDevice>>::default() as Box<dyn Any + Send>)
-                    .boxed_env()
+                future::ok(Box::<Vec<PlaybackDevice>>::default() as Box<dyn Any + Send>).boxed_env()
             }
             Request { url, .. } if url == "http://127.0.0.1:11470/network-info" => {
                 future::ok(Box::new(NetworkInfo {


### PR DESCRIPTION
We now check if 6 hours have passed before calling all addons to fetch the `last-videos` resource 


On the second screenshot there are no call to last-videos once it was retrieved less than 6 hours ago:

![image](https://github.com/Stremio/stremio-core/assets/8925621/c0a4e6b7-2ece-4a32-8a90-e30cfe8ac07f)
![Screenshot from 2023-12-13 13-43-33](https://github.com/Stremio/stremio-core/assets/8925621/f326edf7-31b4-4ddc-8df6-d954f1564532)

