### PR TITLE
Fix/addons last videos ids aggregate request

### DIFF
--- a/src/models/ctx/update_notifications.rs
+++ b/src/models/ctx/update_notifications.rs
@@ -79,7 +79,10 @@ pub fn update_notifications<E: Env + 'static>(
 
             let notifications_catalog_resource_effects =
                 if !sorted_library_items_id_types.is_empty() && should_make_request {
-                    trace!("Sorted by `mtime` LibraryItem id and type: {:?}", sorted_library_items_id_types);
+                    trace!(
+                        "Sorted by `mtime` LibraryItem id and type: {:?}",
+                        sorted_library_items_id_types
+                    );
                     let catalog_resource_effects = resources_update_with_vector_content::<E, _>(
                         notification_catalogs,
                         // force the making of a requests every time PullNotifications is called.

--- a/src/models/ctx/update_notifications.rs
+++ b/src/models/ctx/update_notifications.rs
@@ -5,6 +5,7 @@ use either::Either;
 use futures::FutureExt;
 use lazysort::SortedBy;
 use once_cell::sync::Lazy;
+use tracing::trace;
 
 use crate::{
     constants::{LAST_VIDEOS_IDS_EXTRA_PROP, NOTIFICATIONS_STORAGE_KEY, NOTIFICATION_ITEMS_COUNT},
@@ -78,6 +79,7 @@ pub fn update_notifications<E: Env + 'static>(
 
             let notifications_catalog_resource_effects =
                 if !sorted_library_items_id_types.is_empty() && should_make_request {
+                    trace!("Sorted by `mtime` LibraryItem id and type: {:?}", sorted_library_items_id_types);
                     let catalog_resource_effects = resources_update_with_vector_content::<E, _>(
                         notification_catalogs,
                         // force the making of a requests every time PullNotifications is called.

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -80,6 +80,9 @@ pub enum Internal {
     SearchHistoryChanged,
     /// User notifications have changed
     NotificationsChanged,
+    /// Pulling of notifications triggered either by the user (with an action) or
+    /// internally in core.
+    PullNotifications,
     /// Dismiss all Notifications for a given [`MetaItemId`].
     ///
     /// [`MetaItemId`]: crate::types::resource::MetaItemId

--- a/src/types/addon/manifest.rs
+++ b/src/types/addon/manifest.rs
@@ -155,6 +155,24 @@ impl ManifestCatalog {
             });
         all_supported && required_satisfied
     }
+    pub fn are_extra_names_supported(&self, extra_names: &[String]) -> bool {
+        let all_supported = extra_names.iter().all(|extra_name| {
+            self.extra
+                .iter()
+                .any(|extra_prop| &extra_prop.name == extra_name)
+        });
+        let required_satisfied = self
+            .extra
+            .iter()
+            .filter(|extra_prop| extra_prop.is_required)
+            .all(|extra_prop| {
+                extra_names
+                    .iter()
+                    .any(|extra_name| extra_name == &extra_prop.name)
+            });
+        all_supported && required_satisfied
+    }
+
     pub fn default_required_extra(&self) -> Option<Vec<ExtraValue>> {
         self.extra
             .iter()
@@ -231,6 +249,8 @@ pub struct ExtraProp {
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub options: Vec<String>,
+
+    /// The maximum options that should be passed for this addon extra property.
     #[serde(default)]
     pub options_limit: OptionsLimit,
 }
@@ -269,7 +289,7 @@ impl<'de> DeserializeAs<'de, ExtraProp> for ExtraPropValid {
     }
 }
 
-#[derive(Clone, Deref, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Deref, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct OptionsLimit(pub usize);
 
 impl Default for OptionsLimit {

--- a/src/types/addon/manifest.rs
+++ b/src/types/addon/manifest.rs
@@ -1,13 +1,15 @@
-use crate::constants::SKIP_EXTRA_PROP;
-use crate::types::addon::{ExtraValue, ResourcePath};
-use crate::types::{UniqueVec, UniqueVecAdapter};
+use std::borrow::Cow;
+
 use derivative::Derivative;
 use derive_more::Deref;
 use either::Either;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, DefaultOnError, DefaultOnNull, DeserializeAs, NoneAsEmptyString};
-use std::borrow::Cow;
 use url::Url;
+
+use crate::constants::SKIP_EXTRA_PROP;
+use crate::types::addon::{ExtraValue, ResourcePath};
+use crate::types::{UniqueVec, UniqueVecAdapter};
 
 /// Re-export the semver::Version
 pub use semver::Version;
@@ -30,8 +32,23 @@ pub struct Manifest {
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnError<NoneAsEmptyString>")]
     pub background: Option<Url>,
+    /// Globally supported types.
+    /// We consider the addon to not support any types if the list is empty.
+    ///
+    /// Any [`ManifestResource::Full`] in [`Manifest::resources`] which specifies id prefixes
+    /// should only include prefixes that are present in the globally supported id prefixes,
+    /// if they have been set, i.e. [`Option::Some`]!
+    ///
+    /// Types examples: `movie`, `series`, `anime`, `other`, `tv`, etc.
     pub types: Vec<String>,
     pub resources: Vec<ManifestResource>,
+    /// Globally supported id prefixes by the addon.
+    ///
+    /// Any [`ManifestResource::Full`] in [`Manifest::resources`] which specifies id prefixes
+    /// should only include prefixes that are present in the globally supported id prefixes,
+    /// if they have been set, i.e. [`Option::Some`]!
+    ///
+    /// Prefixes examples: `tt`, `anidb`, `kitsu`, etc.
     pub id_prefixes: Option<Vec<String>>,
     #[serde(default)]
     #[serde_as(deserialize_as = "UniqueVec<Vec<_>, ManifestCatalogUniqueVecAdapter>")]
@@ -105,16 +122,76 @@ pub struct ManifestPreview {
     pub behavior_hints: ManifestBehaviorHints,
 }
 
+/// Resources supported by the addon.
+///
+/// # Examples
+///
+/// ```
+/// use stremio_core::types::addon::ManifestResource;
+///
+/// let short_resource = serde_json::json!("name");
+/// let manifest_resource = serde_json::from_value::<ManifestResource>(short_resource).expect("Valid ManifestResource::Short");
+/// assert_eq!(ManifestResource::Short("name".into()), manifest_resource);
+///
+/// // Full resource definition with `types`` but no `idPrefixes` defined
+/// {
+///     let full_resource = serde_json::json!({
+///         "name": "no-idPrefixes",
+///         "types": ["series", "movies"],
+///     });
+///     let manifest_resource = serde_json::from_value::<ManifestResource>(full_resource).expect("Valid ManifestResource::Full");
+///     assert_eq!(ManifestResource::Full{ name: "no-idPrefixes".into(), types: Some(vec!["series".into(), "movies".into()]), id_prefixes: None}, manifest_resource);
+///
+///     // empty array for types
+///     let full_resource = serde_json::json!({
+///         "name": "no-idPrefixes",
+///         "types": [],
+///     });
+///     let manifest_resource = serde_json::from_value::<ManifestResource>(full_resource).expect("Valid ManifestResource::Full");
+///     assert_eq!(ManifestResource::Full{ name: "no-idPrefixes".into(), types: Some(vec![]), id_prefixes: None}, manifest_resource);
+/// }
+/// // Full resource definition with no `idPrefixes`` but no `types` defined
+/// {
+///     let full_resource = serde_json::json!({
+///         "name": "no-types",
+///         "idPrefixes": ["tt", "kitsu"],
+///     });
+///     let manifest_resource = serde_json::from_value::<ManifestResource>(full_resource).expect("Valid ManifestResource::Full");
+///     assert_eq!(ManifestResource::Full { name: "no-types".into(), types: None, id_prefixes: Some(vec!["tt".into(), "kitsu".into()]) }, manifest_resource);
+///
+///     // empty array for `idPrefixes`
+///     let full_resource = serde_json::json!({
+///         "name": "no-types",
+///         "idPrefixes": [],
+///     });
+///     let manifest_resource = serde_json::from_value::<ManifestResource>(full_resource).expect("Valid ManifestResource::Full");
+///     assert_eq!(ManifestResource::Full { name: "no-types".into(), types: None, id_prefixes: Some(vec![]) }, manifest_resource);
+/// }
+/// ```
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum ManifestResource {
+    /// Short resource format defines only the `name` of the resource
     Short(String),
     #[serde(rename_all = "camelCase")]
     Full {
         name: String,
+        /// The types should be a subset of the ones defined in [`Manifest::types`].
+        #[serde(default)]
         types: Option<Vec<String>>,
+        /// The id prefixes should be a subset of the ones defined in [`Manifest::id_prefixes`].
+        ///
+        /// If `None`, then [`Manifest::id_prefixes`] will be used.
+        #[serde(default)]
         id_prefixes: Option<Vec<String>>,
     },
+}
+
+/// Creates a [`ManifestResource::Short`] resource from a `&str`
+impl From<&str> for ManifestResource {
+    fn from(name: &str) -> Self {
+        ManifestResource::Short(name.to_string())
+    }
 }
 
 impl ManifestResource {
@@ -131,6 +208,7 @@ impl ManifestResource {
 #[serde(rename_all = "camelCase")]
 pub struct ManifestCatalog {
     pub id: String,
+    /// E.g. `movie`, `series`
     pub r#type: String,
     pub name: Option<String>,
     #[serde(flatten)]

--- a/src/types/addon/request.rs
+++ b/src/types/addon/request.rs
@@ -221,7 +221,7 @@ impl AggrRequest<'_> {
                                         // handle the supported catalogs
                                         .filter_map(move |catalog| {
                                             // filter out unsupported by the addon - ids and types
-                                            let supported_ids =
+                                            let mut supported_ids =
                                                 addon.manifest.id_prefixes.as_ref().map(
                                                     |prefixes| {
                                                         id_types
@@ -249,6 +249,7 @@ impl AggrRequest<'_> {
                                                             .collect::<Vec<_>>()
                                                     },
                                                 )?;
+
 
                                             if supported_ids.is_empty() {
                                                 return None;
@@ -281,8 +282,15 @@ impl AggrRequest<'_> {
                                             // make sure we don't make an out-of-bound on the array
                                             let last_index = request_limit.min(supported_ids.len());
                                             let supported_ids_trimmed =
-                                                match supported_ids.get(..last_index) {
-                                                    Some(ids) if !ids.is_empty() => ids.join(","),
+                                                match supported_ids.get_mut(..last_index) {
+                                                    Some(ids) if !ids.is_empty() => {
+                                                        // after we've filtered by recency
+                                                        // we order the ids "alphabetically" for our needs (check `sort()` for more details)
+                                                        // to improve caching in addons
+                                                        ids.sort();
+
+                                                        ids.join(",")
+                                                },
                                                     _ => return None,
                                                 };
                                             // build the extra values

--- a/src/types/addon/request.rs
+++ b/src/types/addon/request.rs
@@ -132,7 +132,6 @@ impl ResourceRequest {
 #[derive(Clone, Debug)]
 pub enum ExtraType {
     /// the extra supports a list of ids
-    ///
     Ids {
         /// The extra name.
         /// It will be checked against the addon manifest to validate it's supported
@@ -250,7 +249,6 @@ impl AggrRequest<'_> {
                                                     },
                                                 )?;
 
-
                                             if supported_ids.is_empty() {
                                                 return None;
                                             }
@@ -290,7 +288,7 @@ impl AggrRequest<'_> {
                                                         ids.sort();
 
                                                         ids.join(",")
-                                                },
+                                                    }
                                                     _ => return None,
                                                 };
                                             // build the extra values

--- a/src/types/addon/request.rs
+++ b/src/types/addon/request.rs
@@ -1,7 +1,8 @@
-use crate::types::addon::{Descriptor, ExtraProp};
 use derive_more::{From, Into};
 use serde::{Deserialize, Serialize};
 use url::Url;
+
+use crate::types::addon::{Descriptor, ExtraProp};
 
 #[derive(Clone, From, Into, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(from = "(String, String)", into = "(String, String)")]
@@ -129,11 +130,33 @@ impl ResourceRequest {
 }
 
 #[derive(Clone, Debug)]
+pub enum ExtraType {
+    /// the extra supports a list of ids
+    ///
+    Ids {
+        /// The extra name.
+        /// It will be checked against the addon manifest to validate it's supported
+        extra_name: String,
+        /// Ids must be ordered if we want to correctly limit the request ids,
+        /// based on the ExtraValue OptionsLimit supported by the addon
+        ids: Vec<String>,
+        ///
+        types: Option<Vec<String>>,
+    },
+}
+
+#[derive(Clone, Debug)]
 pub enum AggrRequest<'a> {
     AllCatalogs {
         extra: &'a Vec<ExtraValue>,
         r#type: &'a Option<String>,
     },
+    CatalogsFiltered(Vec<ExtraType>),
+    // CatalogsFiltered {
+    //     extra: &'a [ExtraValue],
+    //     ids: &'a [String],
+    //     r#type: Option<&'a str>,
+    // },
     AllOfResource(ResourcePath),
 }
 
@@ -170,6 +193,110 @@ impl AggrRequest<'_> {
                         })
                 })
                 .collect(),
+            AggrRequest::CatalogsFiltered(extra_types) => {
+                let extra_names = extra_types
+                    .iter()
+                    .map(|extra_type| match extra_type {
+                        ExtraType::Ids { extra_name, .. } => extra_name.to_owned(),
+                    })
+                    .collect::<Vec<_>>();
+
+                let addon_requests = extra_types
+                    .iter()
+                    .flat_map(|extra_type| match extra_type {
+                        ExtraType::Ids {
+                            extra_name,
+                            ids,
+                            types,
+                        } => {
+                            // TODO: Filter by types
+                            // supported_catalogs.contains(library_item.type)
+
+                            // TODO: Filter by ids prefixes
+                            // addon: support prefix id?
+
+                            // TODO: Limit by addon Manifest extra OptionLimit
+
+                            let resp = addons
+                                .iter()
+                                .flat_map(|addon| {
+                                    addon
+                                        .manifest
+                                        .catalogs
+                                        .iter()
+                                        .filter(|catalog| {
+                                            // check if all extras are supported
+                                            catalog.are_extra_names_supported(&extra_names)
+                                            // Validate if the passed types are supported by the catalog
+                                            && types.as_ref()
+                                                .map(|types| types.contains(&catalog.r#type))
+                                                .unwrap_or(true)
+                                        })
+                                        // handle the supported catalogs
+                                        .filter_map(move |catalog| {
+                                            // filter out unsupported by the addon ids
+                                            let supported_ids =
+                                                addon.manifest.id_prefixes.as_ref().map(
+                                                    |prefixes| {
+                                                        ids.iter()
+                                                            .filter_map(|id| {
+                                                                if prefixes.iter().any(|prefix| {
+                                                                    id.starts_with(prefix)
+                                                                }) {
+                                                                    Some(id.to_owned())
+                                                                } else {
+                                                                    None
+                                                                }
+                                                            })
+                                                            .collect::<Vec<_>>()
+                                                    },
+                                                )?;
+                                            // make sure we respect the addon specified OptionsLimit
+                                            let extra_limit =
+                                                catalog.extra.iter().find_map(|extra_prop| {
+                                                    if &extra_prop.name == extra_name {
+                                                        Some(extra_prop.options_limit)
+                                                    } else {
+                                                        None
+                                                    }
+                                                });
+
+                                            let supported_ids_trimmed = match extra_limit {
+                                                Some(options_limit) => {
+                                                    let last_index = options_limit.0.min(ids.len());
+                                                    supported_ids[..last_index].join(",")
+                                                }
+                                                None => supported_ids.join(","),
+                                            };
+                                            // build the extra values
+                                            let extra = &[ExtraValue {
+                                                name: extra_name.to_owned(),
+                                                value: supported_ids_trimmed,
+                                            }];
+
+                                            Some((
+                                                addon,
+                                                ResourceRequest::new(
+                                                    addon.transport_url.to_owned(),
+                                                    ResourcePath::with_extra(
+                                                        "catalog",
+                                                        &catalog.r#type,
+                                                        &catalog.id,
+                                                        extra,
+                                                    ),
+                                                ),
+                                            ))
+                                        })
+                                })
+                                .collect::<Vec<_>>();
+
+                            resp
+                        }
+                    })
+                    .collect();
+
+                addon_requests
+            }
             AggrRequest::AllOfResource(path) => addons
                 .iter()
                 .filter(|addon| addon.manifest.is_resource_supported(path))

--- a/src/unit_tests/ctx/notifications/pull_notifications_data.json
+++ b/src/unit_tests/ctx/notifications/pull_notifications_data.json
@@ -47,7 +47,7 @@
                         "series"
                     ],
                     "resources": [
-                        "catalogs"
+                        "catalog"
                     ],
                     "idPrefixes": [
                         "tt"

--- a/src/unit_tests/ctx/notifications/update_notifications.rs
+++ b/src/unit_tests/ctx/notifications/update_notifications.rs
@@ -16,7 +16,7 @@ use url::Url;
 use stremio_derive::Model;
 
 use crate::{
-    constants::LAST_VIDEOS_IDS_EXTRA_PROP,
+    constants::{CATALOG_RESOURCE_NAME, LAST_VIDEOS_IDS_EXTRA_PROP},
     models::{
         ctx::Ctx,
         player::{Player, Selected as PlayerSelected},
@@ -76,8 +76,8 @@ fn test_pull_notifications_and_play_in_player() {
             description: None,
             logo: None,
             background: None,
-            types: vec![],
-            resources: vec![],
+            types: vec!["series".into()],
+            resources: vec![CATALOG_RESOURCE_NAME.into()],
             id_prefixes: Some(vec!["tt".to_owned()]),
             catalogs: vec![ManifestCatalog {
                 id: "lastVideosIds".to_owned(),

--- a/src/unit_tests/ctx/notifications/update_notifications.rs
+++ b/src/unit_tests/ctx/notifications/update_notifications.rs
@@ -202,6 +202,7 @@ fn test_pull_notifications_and_play_in_player() {
     }
     let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
     *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+    *NOW.write().unwrap() = Utc.with_ymd_and_hms(2024, 1, 1, 10, 30, 0).unwrap();
     let (runtime, _rx) = Runtime::<TestEnv, _>::new(
         TestModel {
             ctx: Ctx::new(
@@ -343,6 +344,8 @@ fn test_pull_notifications_and_play_in_player() {
             .is_none(),
         "All notifications for this MetaItem should be now dismissed"
     );
+    // before pulling notifications, make sure to update the last_updated time
+    *NOW.write().unwrap() = Utc::now();
     TestEnv::run(|| {
         runtime.dispatch(RuntimeAction {
             field: None,


### PR DESCRIPTION
- [x] Pass the type of the library item alongside it's id in the request
- [x] Limit the request ids by the addon OptionsLimit
- [x] Send the request only to addons that support the id prefix.
- [x] Pull notifications after login
- [x] fix: failing test

### Test with 2 addons supporting lastVideosId where local addon support `kitsu` prefixes while cinemeta does not:

![image](https://github.com/Stremio/stremio-core/assets/8925621/908d0789-0548-429b-9523-2c3d6dfda188)
