### PR TITLE
fix: Hide sensitive information from fmt::Debug for:

### DIFF
--- a/src/types/api/request.rs
+++ b/src/types/api/request.rs
@@ -177,7 +177,7 @@ impl fmt::Debug for AuthRequest {
                 .finish(),
             Self::LoginWithToken { token } => f
                 .debug_struct("LoginWithToken")
-                .field("token", token)
+                .field("token", &"<SENSITIVE>")
                 .finish(),
         }
     }

--- a/src/types/api/request.rs
+++ b/src/types/api/request.rs
@@ -175,7 +175,7 @@ impl fmt::Debug for AuthRequest {
                 .field("password", &"<SENSITIVE>")
                 .field("gdpr_consent", gdpr_consent)
                 .finish(),
-            Self::LoginWithToken { token } => f
+            Self::LoginWithToken { token: _ } => f
                 .debug_struct("LoginWithToken")
                 .field("token", &"<SENSITIVE>")
                 .finish(),

--- a/src/types/api/response.rs
+++ b/src/types/api/response.rs
@@ -73,10 +73,18 @@ pub struct LinkCodeResponse {
     pub qrcode: String,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkAuthKey {
     pub auth_key: String,
+}
+
+impl fmt::Debug for LinkAuthKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkAuthKey")
+            .field("auth_key", &"<SENSITIVE>")
+            .finish()
+    }
 }
 
 #[derive(Clone, TryInto, Serialize, Deserialize, Debug)]

--- a/src/types/api/response.rs
+++ b/src/types/api/response.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::types::{
     addon::Descriptor,
     library::LibraryItem,
@@ -31,11 +33,20 @@ pub struct CollectionResponse {
     pub last_modified: DateTime<Utc>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct AuthResponse {
     #[serde(rename = "authKey")]
     pub key: AuthKey,
     pub user: User,
+}
+
+impl fmt::Debug for AuthResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthResponse")
+            .field("key", &"<SENSITIVE>")
+            .field("user", &self.user)
+            .finish()
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/types/profile/user.rs
+++ b/src/types/profile/user.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 #[cfg(test)]
 use chrono::offset::TimeZone;
 use chrono::serde::ts_seconds;
@@ -8,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnError, DefaultOnNull, DurationSeconds, NoneAsEmptyString};
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
 pub struct TraktInfo {
@@ -20,6 +22,15 @@ pub struct TraktInfo {
     pub expires_in: Duration,
     #[cfg_attr(test, derivative(Default(value = r#"String::from("token")"#)))]
     pub access_token: String,
+}
+impl fmt::Debug for TraktInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TraktInfo")
+            .field("created_at", &self.created_at)
+            .field("expires_in", &self.expires_in)
+            .field("access_token", &"<SENSITIVE>")
+            .finish()
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]


### PR DESCRIPTION
- AuthRequest::LoginWithToken.token
- AuthResponse.key
- TraktInfo::access_token
- LinkAuthKey.auth_key