### PR TITLE
Feat: Added the extra filter option for Watched

### DIFF
--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -528,8 +528,8 @@ impl From<(&String, &LibraryRequest)> for LibraryDeepLinks {
                                 .unwrap()
                         ),
                         (
-                            "stateFilter",
-                            serde_json::to_value(&request.stateFilter)
+                            "watched",
+                            serde_json::to_value(&request.watched)
                                 .unwrap()
                                 .as_str()
                                 .unwrap()
@@ -549,8 +549,8 @@ impl From<(&String, &LibraryRequest)> for LibraryDeepLinks {
                                 .unwrap()
                         ),
                         (
-                            "stateFilter",
-                            serde_json::to_value(&request.stateFilter)
+                            "watched",
+                            serde_json::to_value(&request.watched)
                                 .unwrap()
                                 .as_str()
                                 .unwrap()

--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -528,8 +528,8 @@ impl From<(&String, &LibraryRequest)> for LibraryDeepLinks {
                                 .unwrap()
                         ),
                         (
-                            "watched",
-                            serde_json::to_value(&request.watched)
+                            "filter",
+                            serde_json::to_value(&request.filter)
                                 .unwrap()
                                 .as_str()
                                 .unwrap()
@@ -549,8 +549,8 @@ impl From<(&String, &LibraryRequest)> for LibraryDeepLinks {
                                 .unwrap()
                         ),
                         (
-                            "watched",
-                            serde_json::to_value(&request.watched)
+                            "filter",
+                            serde_json::to_value(&request.filter)
                                 .unwrap()
                                 .as_str()
                                 .unwrap()

--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -527,6 +527,13 @@ impl From<(&String, &LibraryRequest)> for LibraryDeepLinks {
                                 .as_str()
                                 .unwrap()
                         ),
+                        (
+                            "stateFilter",
+                            serde_json::to_value(&request.stateFilter)
+                                .unwrap()
+                                .as_str()
+                                .unwrap()
+                        ),
                         ("page", &request.page.to_string())
                     ]),
                 ),
@@ -537,6 +544,13 @@ impl From<(&String, &LibraryRequest)> for LibraryDeepLinks {
                         (
                             "sort",
                             serde_json::to_value(&request.sort)
+                                .unwrap()
+                                .as_str()
+                                .unwrap()
+                        ),
+                        (
+                            "stateFilter",
+                            serde_json::to_value(&request.stateFilter)
                                 .unwrap()
                                 .as_str()
                                 .unwrap()

--- a/src/models/library_with_filters.rs
+++ b/src/models/library_with_filters.rs
@@ -63,7 +63,7 @@ pub enum Sort {
 #[derive(Derivative, Clone, PartialEq, Eq, EnumIter, Serialize, Deserialize, Debug)]
 #[derivative(Default)]
 #[serde(rename_all = "lowercase")]
-pub enum StateFilter {
+pub enum Watched {
     #[derivative(Default)]
     NotWatched,
     Watched,
@@ -76,7 +76,7 @@ pub struct LibraryRequest {
     #[serde(default)]
     pub sort: Sort,
     #[serde(default)]
-    pub stateFilter: StateFilter,
+    pub watched: Watched,
     #[serde(default)]
     pub page: LibraryRequestPage,
 }
@@ -110,8 +110,8 @@ pub struct SelectableSort {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Debug)]
-pub struct SelectableStateFilter {
-    pub stateFilter: StateFilter,
+pub struct SelectableWatched {
+    pub watched: Watched,
     pub selected: bool,
     pub request: LibraryRequest,
 }
@@ -125,7 +125,7 @@ pub struct SelectablePage {
 pub struct Selectable {
     pub types: Vec<SelectableType>,
     pub sorts: Vec<SelectableSort>,
-    pub stateFilters: Vec<SelectableStateFilter>,
+    pub watcheds: Vec<SelectableWatched>,
     pub prev_page: Option<SelectablePage>,
     pub next_page: Option<SelectablePage>,
 }
@@ -239,9 +239,9 @@ fn selectable_update<F: LibraryFilter>(
                     .as_ref()
                     .map(|selected| selected.request.sort.to_owned())
                     .unwrap_or_default(),
-                stateFilter: selected
+                watched: selected
                     .as_ref()
-                    .map(|selected| selected.request.stateFilter.to_owned())
+                    .map(|selected| selected.request.watched.to_owned())
                     .unwrap_or_default(),
                 page: LibraryRequestPage::default(),
             },
@@ -258,9 +258,9 @@ fn selectable_update<F: LibraryFilter>(
                 .as_ref()
                 .map(|selected| selected.request.sort.to_owned())
                 .unwrap_or_default(),
-            stateFilter: selected
+            watched: selected
                 .as_ref()
-                .map(|selected| selected.request.stateFilter.to_owned())
+                .map(|selected| selected.request.watched.to_owned())
                 .unwrap_or_default(),
             page: LibraryRequestPage::default(),
         },
@@ -279,9 +279,9 @@ fn selectable_update<F: LibraryFilter>(
                     .as_ref()
                     .and_then(|selected| selected.request.r#type.to_owned()),
                 sort: sort.to_owned(),
-                stateFilter: selected
+                watched: selected
                     .as_ref()
-                    .map(|selected| selected.request.stateFilter.to_owned())
+                    .map(|selected| selected.request.watched.to_owned())
                     .unwrap_or_default(),
                 page: LibraryRequestPage::default(),
             },
@@ -291,9 +291,9 @@ fn selectable_update<F: LibraryFilter>(
                 .unwrap_or_default(),
         })
         .collect();
-    let selectable_filters = StateFilter::iter()
-        .map(|stateFilter| SelectableStateFilter {
-            stateFilter: stateFilter.to_owned(),
+    let selectable_filters = Watched::iter()
+        .map(|watched| SelectableWatched {
+            watched: watched.to_owned(),
             request: LibraryRequest {
                 r#type: selected
                     .as_ref()
@@ -302,12 +302,12 @@ fn selectable_update<F: LibraryFilter>(
                     .as_ref()
                     .map(|selected| selected.request.sort.to_owned())
                     .unwrap_or_default(),
-                stateFilter: stateFilter.to_owned(),
+                watched: watched.to_owned(),
                 page: LibraryRequestPage::default(),
             },
             selected: selected
                 .as_ref()
-                .map(|selected| selected.request.stateFilter == stateFilter)
+                .map(|selected| selected.request.watched == watched)
                 .unwrap_or_default(),
         })
         .collect();
@@ -347,7 +347,7 @@ fn selectable_update<F: LibraryFilter>(
     let next_selectable = Selectable {
         types: selectable_types,
         sorts: selectable_sorts,
-        stateFilters: selectable_filters,
+        watcheds: selectable_filters,
         prev_page,
         next_page,
     };
@@ -369,10 +369,10 @@ fn catalog_update<F: LibraryFilter>(
                 Some(r#type) => library_item.r#type == *r#type,
                 None => true,
             })          
-            .filter(|library_item| match &selected.request.stateFilter {
-                StateFilter::NotWatched => !library_item.watched(),
-                StateFilter::Watched => library_item.watched(),
-                StateFilter::Any => true,
+            .filter(|library_item| match &selected.request.watched {
+                Watched::NotWatched => !library_item.watched(),
+                Watched::Watched => library_item.watched(),
+                Watched::Any => true,
             })
             .sorted_by(|a, b| match &selected.request.sort {
                 Sort::LastWatched => b.state.last_watched.cmp(&a.state.last_watched),

--- a/src/types/library/library_item.rs
+++ b/src/types/library/library_item.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::{
     runtime::Env,
-    types::{notifications, resource::{MetaItemBehaviorHints, MetaItemPreview, PosterShape, Video}},
+    types::{resource::{MetaItemBehaviorHints, MetaItemPreview, PosterShape, Video}},
 };
 
 pub type LibraryItemId = String;

--- a/src/types/library/library_item.rs
+++ b/src/types/library/library_item.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::{
     runtime::Env,
-    types::resource::{MetaItemBehaviorHints, MetaItemPreview, PosterShape, Video},
+    types::{notifications, resource::{MetaItemBehaviorHints, MetaItemPreview, PosterShape, Video}},
 };
 
 pub type LibraryItemId = String;

--- a/src/unit_tests/deep_links/library_deep_links.rs
+++ b/src/unit_tests/deep_links/library_deep_links.rs
@@ -1,5 +1,5 @@
 use crate::deep_links::LibraryDeepLinks;
-use crate::models::library_with_filters::{LibraryRequest, Sort};
+use crate::models::library_with_filters::{LibraryRequest, Sort, StateFilter};
 use std::convert::TryFrom;
 
 #[test]
@@ -15,6 +15,7 @@ fn library_deep_links_request_type() {
     let request = LibraryRequest {
         r#type: Some("movie".to_string()),
         sort: Sort::LastWatched,
+        stateFilter: StateFilter::NotWatched,
         page: Default::default(),
     };
     let ldl = LibraryDeepLinks::try_from((&root, &request)).unwrap();
@@ -30,6 +31,7 @@ fn library_deep_links_request_no_type() {
     let request = LibraryRequest {
         r#type: None,
         sort: Sort::LastWatched,
+        stateFilter: StateFilter::NotWatched,
         page: Default::default(),
     };
     let ldl = LibraryDeepLinks::try_from((&root, &request)).unwrap();

--- a/src/unit_tests/deep_links/library_deep_links.rs
+++ b/src/unit_tests/deep_links/library_deep_links.rs
@@ -1,5 +1,5 @@
 use crate::deep_links::LibraryDeepLinks;
-use crate::models::library_with_filters::{LibraryRequest, Sort, StateFilter};
+use crate::models::library_with_filters::{LibraryRequest, Sort, Watched};
 use std::convert::TryFrom;
 
 #[test]
@@ -15,7 +15,7 @@ fn library_deep_links_request_type() {
     let request = LibraryRequest {
         r#type: Some("movie".to_string()),
         sort: Sort::LastWatched,
-        stateFilter: StateFilter::NotWatched,
+        watched: Watched::NotWatched,
         page: Default::default(),
     };
     let ldl = LibraryDeepLinks::try_from((&root, &request)).unwrap();
@@ -31,7 +31,7 @@ fn library_deep_links_request_no_type() {
     let request = LibraryRequest {
         r#type: None,
         sort: Sort::LastWatched,
-        stateFilter: StateFilter::NotWatched,
+        watched: Watched::NotWatched,
         page: Default::default(),
     };
     let ldl = LibraryDeepLinks::try_from((&root, &request)).unwrap();

--- a/src/unit_tests/deep_links/library_deep_links.rs
+++ b/src/unit_tests/deep_links/library_deep_links.rs
@@ -1,5 +1,5 @@
 use crate::deep_links::LibraryDeepLinks;
-use crate::models::library_with_filters::{LibraryRequest, Sort, Watched};
+use crate::models::library_with_filters::{Filter, LibraryRequest, Sort};
 use std::convert::TryFrom;
 
 #[test]
@@ -15,7 +15,7 @@ fn library_deep_links_request_type() {
     let request = LibraryRequest {
         r#type: Some("movie".to_string()),
         sort: Sort::LastWatched,
-        watched: Watched::NotWatched,
+        filter: Filter::NotWatched,
         page: Default::default(),
     };
     let ldl = LibraryDeepLinks::try_from((&root, &request)).unwrap();
@@ -31,7 +31,7 @@ fn library_deep_links_request_no_type() {
     let request = LibraryRequest {
         r#type: None,
         sort: Sort::LastWatched,
-        watched: Watched::NotWatched,
+        filter: Filter::NotWatched,
         page: Default::default(),
     };
     let ldl = LibraryDeepLinks::try_from((&root, &request)).unwrap();


### PR DESCRIPTION
After months and years of waiting for input regarding this feature request, I decided to try to implement it myself. 
# What was done?
Added a new enum called watched, that contains three options
- NotWatched
- Watched
- Any
It works exactly as the sorting but instead, it filters taking into account the watched parameter.

## Chains
https://github.com/Stremio/stremio-web/pull/583
https://github.com/Stremio/stremio-core-web/pull/97

# TODO
- [ ] Improve detection of watched/Not watched to take into account new episodes on shows. Currently for episodes it doesn't make sense that after watching one episode it is tagged as watched.
- [ ] Add translations

# Issues
https://github.com/Stremio/stremio-web/issues/582
https://github.com/Stremio/stremio-features/issues/74
https://github.com/Stremio/stremio-features/issues/552
https://github.com/Stremio/stremio-shell/issues/388