### PR TITLE
fix: mark as watched behavior for meta_details

### DIFF
--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -110,11 +110,11 @@ impl<E: Env + 'static> UpdateWithCtx<E> for MetaDetails {
             Msg::Action(Action::MetaDetails(ActionMetaDetails::MarkAsWatched(is_watched))) => {
                 match &self.library_item {
                     Some(library_item) => {
-                        Effects::msg(Msg::Internal(Internal::LibraryItemMarkAsWatched {
-                            id: library_item.id.clone(),
-                            is_watched: *is_watched,
-                        }))
-                        .unchanged()
+                        let mut library_item = library_item.to_owned();
+                        library_item.mark_as_watched(is_watched);
+
+                        Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(library_item)))
+                            .unchanged()
                     }
                     _ => Effects::none().unchanged(),
                 }

--- a/src/types/library/library_item.rs
+++ b/src/types/library/library_item.rs
@@ -64,12 +64,10 @@ impl LibraryItem {
     }
 
     /// Returns whether the item has been watched when either of the state fields are:
-    /// - `times_watched > 0`
-    /// or
-    /// - `flagged_watched == 1` (true)
     #[inline]
     pub fn watched(&self) -> bool {
-        self.state.times_watched > 0 || self.state.flagged_watched == 1
+        (self.state.flagged_watched == 0 && self.state.times_watched > 0)
+            || self.state.flagged_watched == 1
     }
 
     /// Mark item as watched using `flagged_watched`

--- a/src/types/library/library_item.rs
+++ b/src/types/library/library_item.rs
@@ -72,6 +72,12 @@ impl LibraryItem {
         self.state.times_watched > 0 || self.state.flagged_watched == 1
     }
 
+    /// Mark item as watched using `flagged_watched`
+    #[inline]
+    pub fn mark_as_watched(&mut self, state: &bool) {
+        self.state.flagged_watched = (*state).into();
+    }
+
     /// Pulling notifications relies on a few key things:
     ///
     /// - LibraryItem should not be "other" or "movie", i.e. if you have "series" it will pull notifications

--- a/src/unit_tests/meta_details/mark_as_watched.rs
+++ b/src/unit_tests/meta_details/mark_as_watched.rs
@@ -1,0 +1,118 @@
+use crate::constants::{CINEMETA_URL, META_RESOURCE_NAME, OFFICIAL_ADDONS};
+use crate::models::ctx::Ctx;
+use crate::models::meta_details::{MetaDetails, Selected};
+use crate::runtime::msg::{Action, ActionLoad, ActionMetaDetails};
+use crate::runtime::{EnvFutureExt, Runtime, RuntimeAction, TryEnvFuture};
+use crate::types::addon::{ResourcePath, ResourceResponse};
+use crate::types::profile::Profile;
+use crate::types::resource::{MetaItem, MetaItemBehaviorHints, MetaItemPreview};
+use crate::unit_tests::{default_fetch_handler, Request, TestEnv, FETCH_HANDLER};
+use futures::future;
+use std::any::Any;
+use stremio_derive::Model;
+
+#[test]
+fn mark_as_watched() {
+    #[derive(Model, Default, Clone, Debug)]
+    #[model(TestEnv)]
+    struct TestModel {
+        ctx: Ctx,
+        meta_details: MetaDetails,
+    }
+
+    fn fetch_handler(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+        match request {
+            Request { url, .. } if url == "https://v3-cinemeta.strem.io/meta/movie/tt1.json" => {
+                future::ok(Box::new(ResourceResponse::Meta {
+                    meta: MetaItem {
+                        preview: MetaItemPreview {
+                            id: "tt1".to_owned(),
+                            r#type: "movie".to_owned(),
+                            behavior_hints: MetaItemBehaviorHints {
+                                default_video_id: Some("_tt1".to_owned()),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        },
+                        videos: vec![],
+                    },
+                }) as Box<dyn Any + Send>)
+                .boxed_env()
+            }
+            _ => default_fetch_handler(request),
+        }
+    }
+
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+
+    let (runtime, _rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx {
+                profile: Profile {
+                    addons: OFFICIAL_ADDONS
+                        .iter()
+                        .filter(|addon| addon.transport_url == *CINEMETA_URL)
+                        .cloned()
+                        .collect(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            meta_details: Default::default(),
+        },
+        vec![],
+        1000,
+    );
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Load(ActionLoad::MetaDetails(Selected {
+                meta_path: ResourcePath {
+                    resource: META_RESOURCE_NAME.to_owned(),
+                    r#type: "movie".to_owned(),
+                    id: "tt1".to_owned(),
+                    extra: vec![],
+                },
+                stream_path: None,
+                guess_stream: true,
+            })),
+        });
+    });
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::MetaDetails(ActionMetaDetails::MarkAsWatched(true)),
+        });
+    });
+
+    assert!(
+        runtime
+            .model()
+            .unwrap()
+            .ctx
+            .library
+            .items
+            .get("tt1")
+            .unwrap()
+            .state
+            .flagged_watched
+            == 1,
+        "Should have flagged watched item in library"
+    );
+
+    assert!(
+        runtime
+            .model()
+            .unwrap()
+            .ctx
+            .library
+            .items
+            .get("tt1")
+            .unwrap()
+            .watched(),
+        "Should return library item watched true"
+    );
+}

--- a/src/unit_tests/meta_details/mod.rs
+++ b/src/unit_tests/meta_details/mod.rs
@@ -1,1 +1,2 @@
+mod mark_as_watched;
 mod override_selected;


### PR DESCRIPTION
Closes https://github.com/Stremio/stremio-tasks/issues/203

- Don't forward the event as `LibraryItemMarkAsWatched`
- Fix the condition for the watched function of library_item
- Use `flagged_watched` instead of updating `times_watched`