### PR TITLE
fix: clippy warnings

### DIFF
--- a/src/models/local_search.rs
+++ b/src/models/local_search.rs
@@ -397,7 +397,7 @@ mod test {
 
         assert_eq!(2, searchable_results.len());
 
-        let redirected_id = searchable_results.get(0).unwrap();
+        let redirected_id = searchable_results.first().unwrap();
 
         assert!(redirected_id.name.is_empty());
         assert!(redirected_id.poster.is_none());

--- a/src/types/api/request.rs
+++ b/src/types/api/request.rs
@@ -337,9 +337,7 @@ mod tests {
                 None
             }
 
-            fn body(self) {
-                
-            }
+            fn body(self) {}
         }
 
         let v2 = V2Request;

--- a/src/types/api/request.rs
+++ b/src/types/api/request.rs
@@ -337,8 +337,8 @@ mod tests {
                 None
             }
 
-            fn body(self) -> () {
-                ()
+            fn body(self) {
+                
             }
         }
 

--- a/src/unit_tests/ctx/add_to_library.rs
+++ b/src/unit_tests/ctx/add_to_library.rs
@@ -157,7 +157,7 @@ fn actionctx_addtolibrary() {
         "One request has been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().url.to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().url.to_owned(),
         "https://api.strem.io/api/datastorePut".to_owned(),
         "datastorePut request has been sent"
     );

--- a/src/unit_tests/ctx/authenticate.rs
+++ b/src/unit_tests/ctx/authenticate.rs
@@ -194,7 +194,7 @@ fn actionctx_authenticate_login() {
         "Three requests have been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().to_owned(),
         Request {
             url: "https://api.strem.io/api/login".to_owned(),
             method: "POST".to_owned(),
@@ -396,7 +396,7 @@ fn actionctx_authenticate_login_with_token() {
         "Three requests have been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().to_owned(),
         Request {
             url: "https://api.strem.io/api/loginWithToken".to_owned(),
             method: "POST".to_owned(),
@@ -607,7 +607,7 @@ fn actionctx_authenticate_register() {
         "Three requests have been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().to_owned(),
         Request {
             url: "https://api.strem.io/api/register".to_owned(),
             method: "POST".to_owned(),

--- a/src/unit_tests/ctx/install_addon.rs
+++ b/src/unit_tests/ctx/install_addon.rs
@@ -196,7 +196,7 @@ fn actionctx_installaddon_install_with_user() {
         "One request has been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().to_owned(),
         Request {
             url: "https://api.strem.io/api/addonCollectionSet".to_owned(),
             method: "POST".to_owned(),

--- a/src/unit_tests/ctx/logout.rs
+++ b/src/unit_tests/ctx/logout.rs
@@ -147,7 +147,7 @@ fn actionctx_logout() {
         "One request has been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().to_owned(),
         Request {
             url: "https://api.strem.io/api/logout".to_owned(),
             method: "POST".to_owned(),

--- a/src/unit_tests/ctx/pull_addons_from_api.rs
+++ b/src/unit_tests/ctx/pull_addons_from_api.rs
@@ -187,7 +187,7 @@ fn actionctx_pulladdonsfromapi_with_user() {
         "One request has been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().url,
+        REQUESTS.read().unwrap().first().unwrap().url,
         "https://api.strem.io/api/addonCollectionGet".to_owned(),
         "addonCollectionGet request has been sent"
     );

--- a/src/unit_tests/ctx/push_addons_to_api.rs
+++ b/src/unit_tests/ctx/push_addons_to_api.rs
@@ -162,7 +162,7 @@ fn actionctx_pushaddonstoapi_with_user() {
         "One request has been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().to_owned(),
         Request {
             url: "https://api.strem.io/api/addonCollectionSet".to_owned(),
             method: "POST".to_owned(),

--- a/src/unit_tests/ctx/remove_from_library.rs
+++ b/src/unit_tests/ctx/remove_from_library.rs
@@ -147,7 +147,7 @@ fn actionctx_removefromlibrary() {
         "One request has been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().url.to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().url.to_owned(),
         "https://api.strem.io/api/datastorePut".to_owned(),
         "datastorePut request has been sent"
     );

--- a/src/unit_tests/ctx/rewind_library_item.rs
+++ b/src/unit_tests/ctx/rewind_library_item.rs
@@ -155,7 +155,7 @@ fn actionctx_rewindlibraryitem() {
         "One request has been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().url.to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().url.to_owned(),
         "https://api.strem.io/api/datastorePut".to_owned(),
         "datastorePut request has been sent"
     );

--- a/src/unit_tests/ctx/sync_library_with_api.rs
+++ b/src/unit_tests/ctx/sync_library_with_api.rs
@@ -360,7 +360,7 @@ fn actionctx_synclibrarywithapi_with_user() {
         "Three requests have been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().url,
+        REQUESTS.read().unwrap().first().unwrap().url,
         "https://api.strem.io/api/datastoreMeta".to_owned(),
         "datastoreMeta request has been sent"
     );
@@ -447,7 +447,7 @@ fn actionctx_synclibrarywithapi_with_user_empty_library() {
         "One request has been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().url,
+        REQUESTS.read().unwrap().first().unwrap().url,
         "https://api.strem.io/api/datastoreMeta".to_owned(),
         "datastoreMeta request has been sent"
     );

--- a/src/unit_tests/ctx/uninstall_addon.rs
+++ b/src/unit_tests/ctx/uninstall_addon.rs
@@ -258,7 +258,7 @@ fn actionctx_uninstalladdon_with_user() {
         "One request has been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().to_owned(),
         Request {
             url: "https://api.strem.io/api/addonCollectionSet".to_owned(),
             method: "POST".to_owned(),

--- a/src/unit_tests/link.rs
+++ b/src/unit_tests/link.rs
@@ -116,7 +116,7 @@ fn create_link_code() {
         "Two requests have been sent"
     );
     assert_eq!(
-        REQUESTS.read().unwrap().get(0).unwrap().to_owned(),
+        REQUESTS.read().unwrap().first().unwrap().to_owned(),
         Request {
             url: "https://link.stremio.com/api/v2/create?type=Create".to_owned(),
             method: "GET".to_owned(),


### PR DESCRIPTION
Latest stable release sees new linting warnings showing in core.
This fixes these warnings and replaces the places with the suggestions from clippy