### PR TITLE
fix(player): always update LibraryItem time_offset on NextVideo

### DIFF
--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -544,8 +544,13 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     .library_item
                     .as_mut()
                     .map(|library_item| {
+                        // instantly update the library item's time_offset.
                         library_item.state.time_offset = 0;
-                        push_to_library::<E>(&mut self.push_library_item_time, library_item)
+
+                        Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(
+                            library_item.to_owned(),
+                        )))
+                        .unchanged()
                     })
                     .unwrap_or(Effects::none().unchanged());
 


### PR DESCRIPTION
Steps to reproduce bug:

https://localhost:8080/#/detail/series/tt13210838/tt13210838%3A1%3A2

1. Choose `The gentleman` episode 2 (make sure streams key doesn't contain it, i.e. you have not watched any stream from there)
2. Start playing a stream that's part of a bingewatch group (to see the next video/episode button in player)
3. Jump to time > 50:01, e.g. 55 minutes
4. Click next video episode (from the Seekbar but probably the Pop-up will work as well)
5. Episode 3 starts playing ~ the last second of the video, time_offset hasn't been updated so it tries to load the next episode at the 55 minutes mark (from previous episode)
