### PR TITLE
Trigger state update on LibraryChanged

### DIFF
--- a/src/models/catalog_with_filters.rs
+++ b/src/models/catalog_with_filters.rs
@@ -221,6 +221,7 @@ where
                 &self.catalog,
                 &ctx.profile,
             ),
+            Msg::Internal(Internal::LibraryChanged(_)) => Effects::none(),
             _ => Effects::none().unchanged(),
         }
     }

--- a/src/models/catalogs_with_extra.rs
+++ b/src/models/catalogs_with_extra.rs
@@ -150,6 +150,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for CatalogsWithExtra {
             Msg::Internal(Internal::ProfileChanged) => {
                 catalogs_update::<E>(&mut self.catalogs, &self.selected, None, &ctx.profile)
             }
+            Msg::Internal(Internal::LibraryChanged(_)) => Effects::none(),
             _ => Effects::none().unchanged(),
         }
     }


### PR DESCRIPTION
Return `Effects::none()` on LibraryChanged for `catalog_with_filters` and `catalogs_with_extra`, allowing models to update when the state of a library_item changed
For example, when marking an item as watched from the `meta_details` model