### PR TITLE
Disable WASM sign extension ops for iOS 14 Safari

### DIFF
--- a/stremio-core-web/Cargo.toml
+++ b/stremio-core-web/Cargo.toml
@@ -55,3 +55,7 @@ tracing-wasm = "0.2"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
+
+# iOS 14 Safari does not support WASM sign extension operations
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["--signext-lowering"]

--- a/stremio-core-web/Cargo.toml
+++ b/stremio-core-web/Cargo.toml
@@ -56,6 +56,8 @@ tracing-wasm = "0.2"
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
 
-# iOS 14 Safari does not support WASM sign extension operations
 [package.metadata.wasm-pack.profile.release]
+# iOS 12 Safari - unsupported, flag is insufficient for this version to work and out-of-scope for now
+# iOS 14 Safari - unsupported, we need to use `--signext-lowering`
+# iOS 15 Safari - supported without this flag, current version is tested and works
 wasm-opt = ["--signext-lowering"]


### PR DESCRIPTION
Fixes https://github.com/Stremio/stremio-bugs/issues/868:
Essentially, iOS 14 Safari does not support these WASM instructions, and this simple change allows stremio to load without WASM errors.