### PR TITLE
feat: ExternalPlayerLink - Add moonplayer, vlc and outplayer for visionOS

### DIFF
--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -35,7 +35,7 @@ pub struct OpenPlayerLink {
     pub chromeos: Option<String>,
     pub roku: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    /// Vision Pro os
+    /// VisionOS
     pub visionos: Option<String>,
 }
 

--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -93,6 +93,7 @@ impl From<(&Stream, Option<&Url>, &Settings)> for ExternalPlayerLink {
                     }),
                     "vlc" => Some(OpenPlayerLink {
                         ios: Some(format!("vlc-x-callback://x-callback-url/stream?url={url}")),
+                        visionos: Some(format!("vlc-x-callback://x-callback-url/stream?url={url}")),
                         android: Some(format!(
                             "{}#Intent;package=org.videolan.vlc;type=video;scheme=https;end",
                             http_regex.replace(url, "intent://"),
@@ -115,6 +116,7 @@ impl From<(&Stream, Option<&Url>, &Settings)> for ExternalPlayerLink {
                     }),
                     "outplayer" => Some(OpenPlayerLink {
                         ios: Some(format!("{}", http_regex.replace(url, "outplayer://"))),
+                        visionos: Some(format!("{}", http_regex.replace(url, "outplayer://"))),
                         ..Default::default()
                     }),
                     "infuse" => Some(OpenPlayerLink {

--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -34,6 +34,9 @@ pub struct OpenPlayerLink {
     pub webos: Option<String>,
     pub chromeos: Option<String>,
     pub roku: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Vision Pro os
+    pub visionos: Option<String>,
 }
 
 #[derive(Default, Serialize, Debug, PartialEq, Eq)]
@@ -125,6 +128,10 @@ impl From<(&Stream, Option<&Url>, &Settings)> for ExternalPlayerLink {
                     "mpv" => Some(OpenPlayerLink {
                         macos: Some(format!("mpv://{url}")),
                        ..Default::default()
+                    }),
+                    "moonplayer" => Some(OpenPlayerLink {
+                        visionos: Some(format!("moonplayer://open?url={url}")),
+                        ..Default::default()
                     }),
                     "m3u" => Some(OpenPlayerLink {
                         linux: playlist.to_owned(),


### PR DESCRIPTION
Adds the Moonplayer, VLC and Outplayer (for the Vision Pro) as an external player