### PR TITLE
Fix/ci docs overwritting whole content

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+# Check for outdated actions
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
         
       - name: Deploy gh-pages
         if: ${{ ! startsWith(github.ref, 'refs/pull/')  &&  github.actor != 'dependabot[bot]' }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # the build directory already contains the `github.ref_name` as subfolder(s)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,3 +36,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
+          # we build and publish docs from `development` branch only
+          destination_dir: ./docs/${{ github.ref_name }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           mv target/doc ./docs
 
       - name: Deploy gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs


### PR DESCRIPTION
Docs are now built under a subfolder `docs` and they support branches with `/`.
Fixes a bug where deploying docs from development branch was overwriting the content and removing stremio-core-web npm package builds

![image](https://github.com/user-attachments/assets/037c708d-797a-4d1a-84ec-c52c5efc6c03)
