### PR TITLE
StreamItemState - add default for all fields that are skipped during serialization when None

### DIFF
--- a/src/types/streams/streams_item.rs
+++ b/src/types/streams/streams_item.rs
@@ -27,10 +27,10 @@ pub struct StreamsItem {
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StreamItemState {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subtitle_track: Option<SubtitleTrack>,
     /// In milliseconds
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subtitle_delay: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Subtitles size, platform dependent units
@@ -38,14 +38,14 @@ pub struct StreamItemState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Vertical offset of the subtitles, platform dependent units
     pub subtitle_offset: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audio_track: Option<AudioTrack>,
     /// In milliseconds
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audio_delay: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub playback_speed: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub player_type: Option<String>,
 }
 


### PR DESCRIPTION
Making sure we don't break core deserializatioin when getting a state out of the Local app storage