### PR TITLE
Feature/add new mobile app settings

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -39,7 +39,7 @@ pub const CALENDAR_ITEMS_COUNT: usize = 100;
 pub const WATCHED_THRESHOLD_COEF: f64 = 0.7;
 pub const CREDITS_THRESHOLD_COEF: f64 = 0.9;
 /// The latest migration scheme version
-pub const SCHEMA_VERSION: u32 = 15;
+pub const SCHEMA_VERSION: u32 = 16;
 pub const IMDB_LINK_CATEGORY: &str = "imdb";
 pub const GENRES_LINK_CATEGORY: &str = "Genres";
 pub const CINEMETA_TOP_CATALOG_ID: &str = "top";

--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -271,6 +271,12 @@ pub trait Env {
                         .await?;
                     schema_version = 15;
                 }
+                if schema_version == 15 {
+                    migrate_storage_schema_to_v16::<Self>()
+                        .map_err(|error| EnvError::StorageSchemaVersionUpgrade(Box::new(error)))
+                        .await?;
+                    schema_version = 16;
+                }
                 if schema_version != SCHEMA_VERSION {
                     panic!(
                         "Storage schema version must be upgraded from {} to {}",
@@ -606,6 +612,29 @@ fn migrate_storage_schema_to_v15<E: Env>() -> TryEnvFuture<()> {
         .boxed_env()
 }
 
+fn migrate_storage_schema_to_v16<E: Env>() -> TryEnvFuture<()> {
+    E::get_storage::<serde_json::Value>(PROFILE_STORAGE_KEY)
+        .and_then(|mut profile| {
+            match profile
+                .as_mut()
+                .and_then(|profile| profile.as_object_mut())
+                .and_then(|profile| profile.get_mut("settings"))
+                .and_then(|settings| settings.as_object_mut())
+            {
+                Some(settings) => {
+                    settings.insert(
+                        "serverInForeground".to_owned(),
+                        serde_json::Value::Bool(false),
+                    );
+                    E::set_storage(PROFILE_STORAGE_KEY, Some(&profile))
+                }
+                _ => E::set_storage::<()>(PROFILE_STORAGE_KEY, None),
+            }
+        })
+        .and_then(|_| E::set_storage(SCHEMA_VERSION_STORAGE_KEY, Some(&16)))
+        .boxed_env()
+}
+
 #[cfg(test)]
 mod test {
     use serde_json::{json, Value};
@@ -616,6 +645,7 @@ mod test {
         },
         runtime::{
             env::{
+                migrate_storage_schema_to_v16,
                 migrate_storage_schema_to_v10, migrate_storage_schema_to_v11,
                 migrate_storage_schema_to_v12, migrate_storage_schema_to_v13,
                 migrate_storage_schema_to_v14, migrate_storage_schema_to_v15,
@@ -1149,5 +1179,43 @@ mod test {
         {
             assert_storage_schema_version(15);
         }
+    }
+
+    #[tokio::test]
+    async fn test_migration_from_15_to_16() {
+        let _test_env_guard = TestEnv::reset().expect("Should lock TestEnv");
+
+        let init_profile = json!({
+            "settings": {}
+        });
+
+        let migrated_profile = json!({
+            "settings": {
+                "serverInForeground": false
+            }
+        });
+
+        set_profile_and_schema_version(&init_profile, 15);
+
+        migrate_storage_schema_to_v16::<TestEnv>()
+            .await
+            .expect("Should migrate");
+
+        let storage = STORAGE.read().expect("Should lock");
+
+        assert_eq!(
+            &16.to_string(),
+            storage
+                .get(SCHEMA_VERSION_STORAGE_KEY)
+                .expect("Should have the schema set"),
+            "Scheme version should now be updated"
+        );
+        assert_eq!(
+            &migrated_profile.to_string(),
+            storage
+                .get(PROFILE_STORAGE_KEY)
+                .expect("Should have the serverInForegroundSet set"),
+            "Profile should match"
+        );
     }
 }

--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -628,7 +628,7 @@ fn migrate_storage_schema_to_v16<E: Env>() -> TryEnvFuture<()> {
                     );
                     settings.insert(
                         "sendCrashReports".to_owned(),
-                        serde_json::Value::Bool(false),
+                        serde_json::Value::Bool(true),
                     );
                     E::set_storage(PROFILE_STORAGE_KEY, Some(&profile))
                 }
@@ -1196,7 +1196,7 @@ mod test {
         let migrated_profile = json!({
             "settings": {
                 "serverInForeground": false,
-                "sendCrashReports": false
+                "sendCrashReports": true
             }
         });
 

--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -626,10 +626,7 @@ fn migrate_storage_schema_to_v16<E: Env>() -> TryEnvFuture<()> {
                         "serverInForeground".to_owned(),
                         serde_json::Value::Bool(false),
                     );
-                    settings.insert(
-                        "sendCrashReports".to_owned(),
-                        serde_json::Value::Bool(true),
-                    );
+                    settings.insert("sendCrashReports".to_owned(), serde_json::Value::Bool(true));
                     E::set_storage(PROFILE_STORAGE_KEY, Some(&profile))
                 }
                 _ => E::set_storage::<()>(PROFILE_STORAGE_KEY, None),

--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -626,6 +626,10 @@ fn migrate_storage_schema_to_v16<E: Env>() -> TryEnvFuture<()> {
                         "serverInForeground".to_owned(),
                         serde_json::Value::Bool(false),
                     );
+                    settings.insert(
+                        "sendCrashReports".to_owned(),
+                        serde_json::Value::Bool(false),
+                    );
                     E::set_storage(PROFILE_STORAGE_KEY, Some(&profile))
                 }
                 _ => E::set_storage::<()>(PROFILE_STORAGE_KEY, None),
@@ -1191,7 +1195,8 @@ mod test {
 
         let migrated_profile = json!({
             "settings": {
-                "serverInForeground": false
+                "serverInForeground": false,
+                "sendCrashReports": false
             }
         });
 
@@ -1214,7 +1219,7 @@ mod test {
             &migrated_profile.to_string(),
             storage
                 .get(PROFILE_STORAGE_KEY)
-                .expect("Should have the serverInForegroundSet set"),
+                .expect("Should have the profile set"),
             "Profile should match"
         );
     }

--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -649,12 +649,12 @@ mod test {
         },
         runtime::{
             env::{
-                migrate_storage_schema_to_v16,
                 migrate_storage_schema_to_v10, migrate_storage_schema_to_v11,
                 migrate_storage_schema_to_v12, migrate_storage_schema_to_v13,
                 migrate_storage_schema_to_v14, migrate_storage_schema_to_v15,
-                migrate_storage_schema_to_v6, migrate_storage_schema_to_v7,
-                migrate_storage_schema_to_v8, migrate_storage_schema_to_v9,
+                migrate_storage_schema_to_v16, migrate_storage_schema_to_v6,
+                migrate_storage_schema_to_v7, migrate_storage_schema_to_v8,
+                migrate_storage_schema_to_v9,
             },
             Env,
         },

--- a/src/types/profile/settings.rs
+++ b/src/types/profile/settings.rs
@@ -80,7 +80,7 @@ impl Default for Settings {
             surround_sound: false,
             streaming_server_warning_dismissed: None,
             server_in_foreground: false,
-            send_crash_reports: false,
+            send_crash_reports: true,
         }
     }
 }

--- a/src/types/profile/settings.rs
+++ b/src/types/profile/settings.rs
@@ -38,7 +38,8 @@ pub struct Settings {
     pub pause_on_minimize: bool,
     pub surround_sound: bool,
     pub streaming_server_warning_dismissed: Option<DateTime<Utc>>,
-    pub server_in_foreground: bool
+    pub server_in_foreground: bool,
+    pub send_crash_reports: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -78,7 +79,8 @@ impl Default for Settings {
             pause_on_minimize: false,
             surround_sound: false,
             streaming_server_warning_dismissed: None,
-            server_in_foreground: false
+            server_in_foreground: false,
+            send_crash_reports: false,
         }
     }
 }

--- a/src/types/profile/settings.rs
+++ b/src/types/profile/settings.rs
@@ -38,6 +38,7 @@ pub struct Settings {
     pub pause_on_minimize: bool,
     pub surround_sound: bool,
     pub streaming_server_warning_dismissed: Option<DateTime<Utc>>,
+    pub server_in_foreground: bool
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -77,6 +78,7 @@ impl Default for Settings {
             pause_on_minimize: false,
             surround_sound: false,
             streaming_server_warning_dismissed: None,
+            server_in_foreground: false
         }
     }
 }

--- a/src/unit_tests/serde/default_tokens_ext.rs
+++ b/src/unit_tests/serde/default_tokens_ext.rs
@@ -438,7 +438,7 @@ impl DefaultTokens for Settings {
             Token::Str("serverInForeground"),
             Token::Bool(false),
             Token::Str("sendCrashReports"),
-            Token::Bool(false),
+            Token::Bool(true),
             Token::StructEnd,
         ]
     }

--- a/src/unit_tests/serde/default_tokens_ext.rs
+++ b/src/unit_tests/serde/default_tokens_ext.rs
@@ -374,7 +374,7 @@ impl DefaultTokens for Settings {
         vec![
             Token::Struct {
                 name: "Settings",
-                len: 27,
+                len: 28,
             },
             Token::Str("interfaceLanguage"),
             Token::Str("eng"),
@@ -435,6 +435,8 @@ impl DefaultTokens for Settings {
             Token::Bool(false),
             Token::Str("streamingServerWarningDismissed"),
             Token::None,
+            Token::Str("serverInForeground"),
+            Token::Bool(false),
             Token::StructEnd,
         ]
     }

--- a/src/unit_tests/serde/default_tokens_ext.rs
+++ b/src/unit_tests/serde/default_tokens_ext.rs
@@ -374,7 +374,7 @@ impl DefaultTokens for Settings {
         vec![
             Token::Struct {
                 name: "Settings",
-                len: 28,
+                len: 29,
             },
             Token::Str("interfaceLanguage"),
             Token::Str("eng"),
@@ -436,6 +436,8 @@ impl DefaultTokens for Settings {
             Token::Str("streamingServerWarningDismissed"),
             Token::None,
             Token::Str("serverInForeground"),
+            Token::Bool(false),
+            Token::Str("sendCrashReports"),
             Token::Bool(false),
             Token::StructEnd,
         ]

--- a/src/unit_tests/serde/settings.rs
+++ b/src/unit_tests/serde/settings.rs
@@ -36,11 +36,12 @@ fn settings() {
             streaming_server_warning_dismissed: Some(
                 Utc.with_ymd_and_hms(2021, 1, 1, 0, 0, 0).unwrap(),
             ),
+            server_in_foreground: false
         },
         &[
             Token::Struct {
                 name: "Settings",
-                len: 27,
+                len: 28,
             },
             Token::Str("interfaceLanguage"),
             Token::Str("interface_language"),
@@ -105,6 +106,8 @@ fn settings() {
             Token::Str("streamingServerWarningDismissed"),
             Token::Some,
             Token::Str("2021-01-01T00:00:00Z"),
+            Token::Str("serverInForeground"),
+            Token::Bool(false),
             Token::StructEnd,
         ],
     );
@@ -117,7 +120,7 @@ fn settings_de() {
         &[
             Token::Struct {
                 name: "Settings",
-                len: 22,
+                len: 23,
             },
             Token::Str("interfaceLanguage"),
             Token::Str("eng"),
@@ -174,6 +177,8 @@ fn settings_de() {
             Token::Bool(false),
             Token::Str("streamingServerWarningDismissed"),
             Token::None,
+            Token::Str("serverInForeground"),
+            Token::Bool(false),
             Token::StructEnd,
         ],
     );

--- a/src/unit_tests/serde/settings.rs
+++ b/src/unit_tests/serde/settings.rs
@@ -37,7 +37,7 @@ fn settings() {
                 Utc.with_ymd_and_hms(2021, 1, 1, 0, 0, 0).unwrap(),
             ),
             server_in_foreground: false,
-            send_crash_reports: false,
+            send_crash_reports: true,
         },
         &[
             Token::Struct {
@@ -110,7 +110,7 @@ fn settings() {
             Token::Str("serverInForeground"),
             Token::Bool(false),
             Token::Str("sendCrashReports"),
-            Token::Bool(false),
+            Token::Bool(true),
             Token::StructEnd,
         ],
     );
@@ -183,7 +183,7 @@ fn settings_de() {
             Token::Str("serverInForeground"),
             Token::Bool(false),
             Token::Str("sendCrashReports"),
-            Token::Bool(false),
+            Token::Bool(true),
             Token::StructEnd,
         ],
     );

--- a/src/unit_tests/serde/settings.rs
+++ b/src/unit_tests/serde/settings.rs
@@ -36,12 +36,13 @@ fn settings() {
             streaming_server_warning_dismissed: Some(
                 Utc.with_ymd_and_hms(2021, 1, 1, 0, 0, 0).unwrap(),
             ),
-            server_in_foreground: false
+            server_in_foreground: false,
+            send_crash_reports: false,
         },
         &[
             Token::Struct {
                 name: "Settings",
-                len: 28,
+                len: 29,
             },
             Token::Str("interfaceLanguage"),
             Token::Str("interface_language"),
@@ -108,6 +109,8 @@ fn settings() {
             Token::Str("2021-01-01T00:00:00Z"),
             Token::Str("serverInForeground"),
             Token::Bool(false),
+            Token::Str("sendCrashReports"),
+            Token::Bool(false),
             Token::StructEnd,
         ],
     );
@@ -120,7 +123,7 @@ fn settings_de() {
         &[
             Token::Struct {
                 name: "Settings",
-                len: 23,
+                len: 24,
             },
             Token::Str("interfaceLanguage"),
             Token::Str("eng"),
@@ -178,6 +181,8 @@ fn settings_de() {
             Token::Str("streamingServerWarningDismissed"),
             Token::None,
             Token::Str("serverInForeground"),
+            Token::Bool(false),
+            Token::Str("sendCrashReports"),
             Token::Bool(false),
             Token::StructEnd,
         ],


### PR DESCRIPTION
this add two new settings needed for the mobile app
one is for the service to be always in the foreground
another one is for sending crash reports

Can be implemented / tested in stremio-web using:
- Dev build(with trace logging): https://stremio.github.io/stremio-core/stremio-core-web/feature/add-new-mobile-app-settings/dev/stremio-stremio-core-web-0.48.1.tgz
- Release build: https://stremio.github.io/stremio-core/stremio-core-web/feature/add-new-mobile-app-settings/stremio-stremio-core-web-0.48.1.tgz