### PR TITLE
feat: add ctx delete account action

### DIFF
--- a/src/models/ctx/update_events.rs
+++ b/src/models/ctx/update_events.rs
@@ -18,7 +18,7 @@ pub fn update_events<E: Env + 'static>(
     msg: &Msg,
 ) -> Effects {
     match msg {
-        Msg::Action(Action::Ctx(ActionCtx::Logout)) | Msg::Internal(Internal::Logout) => {
+        Msg::Internal(Internal::Logout(_)) => {
             let next_dismissed_events = DismissedEventsBucket::default();
             *dismissed_events = next_dismissed_events;
             Effects::msg(Msg::Internal(Internal::DismissedEventsChanged))

--- a/src/models/ctx/update_library.rs
+++ b/src/models/ctx/update_library.rs
@@ -33,7 +33,7 @@ pub fn update_library<E: Env + 'static>(
 ) -> Effects {
     let auth_key = profile.auth_key();
     match msg {
-        Msg::Action(Action::Ctx(ActionCtx::Logout)) | Msg::Internal(Internal::Logout) => {
+        Msg::Internal(Internal::Logout(_)) => {
             let next_library = LibraryBucket::default();
             if *library != next_library {
                 *library = next_library;

--- a/src/models/ctx/update_notifications.rs
+++ b/src/models/ctx/update_notifications.rs
@@ -122,7 +122,7 @@ pub fn update_notifications<E: Env + 'static>(
             Msg::Internal(Internal::DismissNotificationItem(id.to_owned())),
         )
         .unchanged(),
-        Msg::Action(Action::Ctx(ActionCtx::Logout)) | Msg::Internal(Internal::Logout) => {
+        Msg::Internal(Internal::Logout(_)) => {
             let notification_catalogs_effects = eq_update(notification_catalogs, vec![]);
             let next_notifications = NotificationsBucket::new::<E>(profile.uid(), vec![]);
             let notifications_effects = if *notifications != next_notifications {

--- a/src/models/ctx/update_profile.rs
+++ b/src/models/ctx/update_profile.rs
@@ -11,7 +11,7 @@ use crate::types::addon::Descriptor;
 use crate::types::api::{
     fetch_api, APIError, APIRequest, APIResult, CollectionResponse, SuccessResponse,
 };
-use crate::types::profile::{Auth, AuthKey, Profile, Settings, User};
+use crate::types::profile::{Auth, AuthKey, Password, Profile, Settings, User};
 use crate::types::streams::StreamsBucket;
 
 pub fn update_profile<E: Env + 'static>(
@@ -510,7 +510,7 @@ fn push_profile_to_storage<E: Env + 'static>(profile: &Profile) -> Effect {
     .into()
 }
 
-fn delete_account<E: Env + 'static>(auth_key: &AuthKey, password: &str) -> Effect {
+fn delete_account<E: Env + 'static>(auth_key: &AuthKey, password: &Password) -> Effect {
     let request = APIRequest::DeleteAccount {
         auth_key: auth_key.to_owned(),
         password: password.to_owned(),

--- a/src/models/ctx/update_profile.rs
+++ b/src/models/ctx/update_profile.rs
@@ -21,7 +21,7 @@ pub fn update_profile<E: Env + 'static>(
     msg: &Msg,
 ) -> Effects {
     match msg {
-        Msg::Action(Action::Ctx(ActionCtx::Logout)) | Msg::Internal(Internal::Logout) => {
+        Msg::Internal(Internal::Logout(_)) => {
             let next_profile = Profile::default();
             if *profile != next_profile {
                 *profile = next_profile;
@@ -377,7 +377,7 @@ pub fn update_profile<E: Env + 'static>(
                 Err(error) => {
                     let session_expired_effects = match error {
                         CtxError::API(APIError { code, .. }) if *code == 1 => {
-                            Effects::msg(Msg::Internal(Internal::Logout)).unchanged()
+                            Effects::msg(Msg::Internal(Internal::Logout(false))).unchanged()
                         }
                         _ => Effects::none().unchanged(),
                     };
@@ -394,7 +394,7 @@ pub fn update_profile<E: Env + 'static>(
             APIRequest::DeleteAccount { auth_key, .. },
             result,
         )) if profile.auth_key() == Some(auth_key) => match result {
-            Ok(_) => Effects::msg(Msg::Internal(Internal::Logout)).unchanged(),
+            Ok(_) => Effects::msg(Msg::Internal(Internal::Logout(true))).unchanged(),
             Err(error) => Effects::msg(Msg::Event(Event::Error {
                 error: error.to_owned(),
                 source: Box::new(Event::UserAccountDeleted { uid: profile.uid() }),

--- a/src/models/ctx/update_profile.rs
+++ b/src/models/ctx/update_profile.rs
@@ -510,7 +510,7 @@ fn push_profile_to_storage<E: Env + 'static>(profile: &Profile) -> Effect {
     .into()
 }
 
-fn delete_account<E: Env + 'static>(auth_key: &AuthKey, password: &String) -> Effect {
+fn delete_account<E: Env + 'static>(auth_key: &AuthKey, password: &str) -> Effect {
     let request = APIRequest::DeleteAccount {
         auth_key: auth_key.to_owned(),
         password: password.to_owned(),

--- a/src/models/ctx/update_search_history.rs
+++ b/src/models/ctx/update_search_history.rs
@@ -13,7 +13,7 @@ pub fn update_search_history<E: Env + 'static>(
     msg: &Msg,
 ) -> Effects {
     match msg {
-        Msg::Action(Action::Ctx(ActionCtx::Logout)) | Msg::Internal(Internal::Logout) => {
+        Msg::Internal(Internal::Logout(_)) => {
             let next_search_history = SearchHistoryBucket::default();
             *search_history = next_search_history;
             Effects::msg(Msg::Internal(Internal::SearchHistoryChanged))

--- a/src/models/ctx/update_streams.rs
+++ b/src/models/ctx/update_streams.rs
@@ -5,7 +5,7 @@ use std::collections::hash_map::Entry;
 use crate::constants::STREAMS_STORAGE_KEY;
 use crate::models::common::{Loadable, ResourceLoadable};
 use crate::models::ctx::{CtxError, CtxStatus};
-use crate::runtime::msg::{Action, ActionCtx, CtxAuthResponse, Event, Internal, Msg};
+use crate::runtime::msg::{CtxAuthResponse, Event, Internal, Msg};
 use crate::runtime::{Effect, EffectFuture, Effects, Env, EnvFutureExt};
 use crate::types::streams::{StreamsBucket, StreamsItem, StreamsItemKey};
 
@@ -15,7 +15,7 @@ pub fn update_streams<E: Env + 'static>(
     msg: &Msg,
 ) -> Effects {
     match msg {
-        Msg::Action(Action::Ctx(ActionCtx::Logout)) | Msg::Internal(Internal::Logout) => {
+        Msg::Internal(Internal::Logout(_)) => {
             let next_streams = StreamsBucket::default();
             if *streams != next_streams {
                 *streams = next_streams;

--- a/src/models/ctx/update_trakt_addon.rs
+++ b/src/models/ctx/update_trakt_addon.rs
@@ -23,9 +23,7 @@ pub fn update_trakt_addon<E: Env + 'static>(
     msg: &Msg,
 ) -> Effects {
     match msg {
-        Msg::Action(Action::Ctx(ActionCtx::Logout)) | Msg::Internal(Internal::Logout) => {
-            eq_update(trakt_addon, None)
-        }
+        Msg::Internal(Internal::Logout(_)) => eq_update(trakt_addon, None),
         Msg::Action(Action::Ctx(ActionCtx::InstallTraktAddon)) => {
             Effects::msg(Msg::Internal(Internal::InstallTraktAddon))
         }

--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -34,6 +34,7 @@ use crate::{
 pub enum ActionCtx {
     Authenticate(AuthRequest),
     Logout,
+    DeleteAccount(String),
     InstallAddon(Descriptor),
     InstallTraktAddon,
     LogoutTrakt,

--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -3,6 +3,7 @@ use std::ops::Range;
 use serde::Deserialize;
 use url::Url;
 
+use crate::types::profile::Password;
 use crate::types::streams::StreamItemState;
 use crate::{
     models::{
@@ -34,7 +35,7 @@ use crate::{
 pub enum ActionCtx {
     Authenticate(AuthRequest),
     Logout,
-    DeleteAccount(String),
+    DeleteAccount(Password),
     InstallAddon(Descriptor),
     InstallTraktAddon,
     LogoutTrakt,

--- a/src/runtime/msg/event.rs
+++ b/src/runtime/msg/event.rs
@@ -88,6 +88,9 @@ pub enum Event {
     UserLoggedOut {
         uid: UID,
     },
+    UserAccountDeleted {
+        uid: UID,
+    },
     SessionDeleted {
         auth_key: AuthKey,
     },

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -49,6 +49,8 @@ pub enum Internal {
     AddonsAPIResult(APIRequest, Result<Vec<Descriptor>, CtxError>),
     /// Result for pull user from API.
     UserAPIResult(APIRequest, Result<User, CtxError>),
+    /// Result for deleting account from API.
+    DeleteAccountAPIResult(APIRequest, Result<SuccessResponse, CtxError>),
     /// Result for library sync plan with API.
     LibrarySyncPlanResult(DatastoreRequest, Result<LibraryPlanResponse, CtxError>),
     /// Result for pull library items from API.

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -55,8 +55,8 @@ pub enum Internal {
     LibrarySyncPlanResult(DatastoreRequest, Result<LibraryPlanResponse, CtxError>),
     /// Result for pull library items from API.
     LibraryPullResult(DatastoreRequest, Result<Vec<LibraryItem>, CtxError>),
-    /// Dispatched when expired session is detected
-    Logout,
+    /// Dispatched when the user session needs to be cleared with a flag if the session was already deleted server-side
+    Logout(bool),
     /// Internal event dispatched on user action or login
     /// to install the addon if it's not present
     InstallTraktAddon,

--- a/src/types/api/request.rs
+++ b/src/types/api/request.rs
@@ -51,6 +51,7 @@ pub enum APIRequest {
     },
     #[serde(rename_all = "camelCase")]
     DeleteAccount {
+        auth_key: AuthKey,
         password: String,
     },
     #[serde(rename_all = "camelCase")]

--- a/src/types/api/request.rs
+++ b/src/types/api/request.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use crate::constants::{API_URL, LINK_API_URL};
 use crate::types::addon::Descriptor;
 use crate::types::library::LibraryItem;
-use crate::types::profile::{AuthKey, GDPRConsent, User};
+use crate::types::profile::{AuthKey, GDPRConsent, Password, User};
 use crate::types::resource::SeriesInfo;
 use chrono::{DateTime, Local};
 #[cfg(test)]
@@ -52,7 +52,7 @@ pub enum APIRequest {
     #[serde(rename_all = "camelCase")]
     DeleteAccount {
         auth_key: AuthKey,
-        password: String,
+        password: Password,
     },
     #[serde(rename_all = "camelCase")]
     AddonCollectionGet {

--- a/src/types/api/request.rs
+++ b/src/types/api/request.rs
@@ -50,6 +50,10 @@ pub enum APIRequest {
         auth_key: AuthKey,
     },
     #[serde(rename_all = "camelCase")]
+    DeleteAccount {
+        password: String,
+    },
+    #[serde(rename_all = "camelCase")]
     AddonCollectionGet {
         auth_key: AuthKey,
         update: bool,
@@ -155,6 +159,7 @@ impl FetchRequestParams<APIRequest> for APIRequest {
             APIRequest::Auth(AuthRequest::Facebook { .. }) => "authWithFacebook".to_owned(),
             APIRequest::Auth(AuthRequest::Register { .. }) => "register".to_owned(),
             APIRequest::Logout { .. } => "logout".to_owned(),
+            APIRequest::DeleteAccount { .. } => "deleteUser".to_owned(),
             APIRequest::AddonCollectionGet { .. } => "addonCollectionGet".to_owned(),
             APIRequest::AddonCollectionSet { .. } => "addonCollectionSet".to_owned(),
             APIRequest::GetUser { .. } => "getUser".to_owned(),

--- a/src/types/profile/auth.rs
+++ b/src/types/profile/auth.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
 use crate::types::profile::User;
 use serde::{Deserialize, Serialize};
@@ -18,4 +18,20 @@ impl Display for AuthKey {
 pub struct Auth {
     pub key: AuthKey,
     pub user: User,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Default))]
+pub struct Password(pub String);
+
+impl Display for Password {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Debug for Password {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<SENSITIVE>>")
+    }
 }

--- a/src/unit_tests/ctx/delete_account.rs
+++ b/src/unit_tests/ctx/delete_account.rs
@@ -1,18 +1,22 @@
-use crate::constants::PROFILE_STORAGE_KEY;
-use crate::models::ctx::Ctx;
-use crate::runtime::msg::{Action, ActionCtx};
-use crate::runtime::{Env, EnvFutureExt, Runtime, RuntimeAction, TryEnvFuture};
-use crate::types::api::{APIResult, SuccessResponse};
-use crate::types::events::DismissedEventsBucket;
-use crate::types::library::LibraryBucket;
-use crate::types::notifications::NotificationsBucket;
-use crate::types::profile::{Auth, AuthKey, GDPRConsent, Profile, User};
-use crate::types::search_history::SearchHistoryBucket;
-use crate::types::server_urls::ServerUrlsBucket;
-use crate::types::streams::StreamsBucket;
-use crate::types::True;
-use crate::unit_tests::{
-    default_fetch_handler, Request, TestEnv, FETCH_HANDLER, REQUESTS, STORAGE,
+use crate::{
+    constants::PROFILE_STORAGE_KEY,
+    models::ctx::Ctx,
+    runtime::{
+        msg::{Action, ActionCtx},
+        Env, EnvFutureExt, Runtime, RuntimeAction, TryEnvFuture,
+    },
+    types::{
+        api::{APIResult, SuccessResponse},
+        events::DismissedEventsBucket,
+        library::LibraryBucket,
+        notifications::NotificationsBucket,
+        profile::{Auth, AuthKey, GDPRConsent, Profile, User},
+        search_history::SearchHistoryBucket,
+        server_urls::ServerUrlsBucket,
+        streams::StreamsBucket,
+        True,
+    },
+    unit_tests::{default_fetch_handler, Request, TestEnv, FETCH_HANDLER, REQUESTS, STORAGE},
 };
 use futures::future;
 use std::any::Any;

--- a/src/unit_tests/ctx/delete_account.rs
+++ b/src/unit_tests/ctx/delete_account.rs
@@ -1,0 +1,157 @@
+use crate::constants::PROFILE_STORAGE_KEY;
+use crate::models::ctx::Ctx;
+use crate::runtime::msg::{Action, ActionCtx};
+use crate::runtime::{Env, EnvFutureExt, Runtime, RuntimeAction, TryEnvFuture};
+use crate::types::api::{APIResult, SuccessResponse};
+use crate::types::events::DismissedEventsBucket;
+use crate::types::library::LibraryBucket;
+use crate::types::notifications::NotificationsBucket;
+use crate::types::profile::{Auth, AuthKey, GDPRConsent, Profile, User};
+use crate::types::search_history::SearchHistoryBucket;
+use crate::types::server_urls::ServerUrlsBucket;
+use crate::types::streams::StreamsBucket;
+use crate::types::True;
+use crate::unit_tests::{
+    default_fetch_handler, Request, TestEnv, FETCH_HANDLER, REQUESTS, STORAGE,
+};
+use futures::future;
+use std::any::Any;
+use stremio_derive::Model;
+
+#[test]
+fn actionctx_delete_account() {
+    #[derive(Model, Clone, Default)]
+    #[model(TestEnv)]
+    struct TestModel {
+        ctx: Ctx,
+    }
+
+    fn fetch_handler(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+        match request {
+            Request {
+                url, method, body, ..
+            } if url == "https://api.strem.io/api/deleteUser"
+                && method == "POST"
+                && body == "{\"type\":\"DeleteAccount\",\"password\":\"password\"}" =>
+            {
+                future::ok(
+                    Box::new(APIResult::Ok(SuccessResponse { success: True {} }))
+                        as Box<dyn Any + Send>,
+                )
+                .boxed_env()
+            }
+            Request {
+                url, method, body, ..
+            } if url == "https://api.strem.io/api/logout"
+                && method == "POST"
+                && body == "{\"type\":\"Logout\",\"authKey\":\"auth_key\"}" =>
+            {
+                future::ok(
+                    Box::new(APIResult::Ok(SuccessResponse { success: True {} }))
+                        as Box<dyn Any + Send>,
+                )
+                .boxed_env()
+            }
+            _ => default_fetch_handler(request),
+        }
+    }
+
+    let profile = Profile {
+        auth: Some(Auth {
+            key: AuthKey("auth_key".to_owned()),
+            user: User {
+                id: "user_id".to_owned(),
+                email: "user_email".to_owned(),
+                fb_id: None,
+                avatar: None,
+                last_modified: TestEnv::now(),
+                date_registered: TestEnv::now(),
+                trakt: None,
+                premium_expire: None,
+                gdpr_consent: GDPRConsent {
+                    tos: true,
+                    privacy: true,
+                    marketing: true,
+                    from: Some("tests".to_owned()),
+                },
+            },
+        }),
+        ..Default::default()
+    };
+
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+
+    STORAGE.write().unwrap().insert(
+        PROFILE_STORAGE_KEY.to_owned(),
+        serde_json::to_string(&profile).unwrap(),
+    );
+
+    let (runtime, _rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx::new(
+                profile,
+                LibraryBucket::default(),
+                StreamsBucket::default(),
+                ServerUrlsBucket::new::<TestEnv>(None),
+                NotificationsBucket::new::<TestEnv>(None, vec![]),
+                SearchHistoryBucket::default(),
+                DismissedEventsBucket::default(),
+            ),
+        },
+        vec![],
+        1000,
+    );
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Ctx(ActionCtx::DeleteAccount("password".to_owned())),
+        })
+    });
+
+    assert_eq!(
+        runtime.model().unwrap().ctx.profile,
+        Default::default(),
+        "profile updated successfully in memory"
+    );
+
+    assert!(
+        STORAGE
+            .read()
+            .unwrap()
+            .get(PROFILE_STORAGE_KEY)
+            .map_or(false, |data| {
+                serde_json::from_str::<Profile>(data).unwrap() == Default::default()
+            }),
+        "profile updated successfully in storage"
+    );
+
+    assert_eq!(
+        REQUESTS.read().unwrap().len(),
+        2,
+        "Two requests have been sent"
+    );
+
+    assert_eq!(
+        REQUESTS.read().unwrap().get(0).unwrap().to_owned(),
+        Request {
+            url: "https://api.strem.io/api/deleteUser".to_owned(),
+            method: "POST".to_owned(),
+            body: "{\"type\":\"DeleteAccount\",\"password\":\"password\"}".to_owned(),
+            ..Default::default()
+        },
+        "Delete account request has been sent"
+    );
+
+    assert_eq!(
+        REQUESTS.read().unwrap().get(1).unwrap().to_owned(),
+        Request {
+            url: "https://api.strem.io/api/logout".to_owned(),
+            method: "POST".to_owned(),
+            body: "{\"type\":\"Logout\",\"authKey\":\"auth_key\"}".to_owned(),
+            ..Default::default()
+        },
+        "Logout request has been sent"
+    );
+}

--- a/src/unit_tests/ctx/delete_account.rs
+++ b/src/unit_tests/ctx/delete_account.rs
@@ -32,7 +32,7 @@ fn actionctx_delete_account() {
                 url, method, body, ..
             } if url == "https://api.strem.io/api/deleteUser"
                 && method == "POST"
-                && body == "{\"type\":\"DeleteAccount\",\"password\":\"password\"}" =>
+                && body == "{\"type\":\"DeleteAccount\",\"authKey\":\"auth_key\",\"password\":\"password\"}" =>
             {
                 future::ok(
                     Box::new(APIResult::Ok(SuccessResponse { success: True {} }))
@@ -138,7 +138,8 @@ fn actionctx_delete_account() {
         Request {
             url: "https://api.strem.io/api/deleteUser".to_owned(),
             method: "POST".to_owned(),
-            body: "{\"type\":\"DeleteAccount\",\"password\":\"password\"}".to_owned(),
+            body: "{\"type\":\"DeleteAccount\",\"authKey\":\"auth_key\",\"password\":\"password\"}"
+                .to_owned(),
             ..Default::default()
         },
         "Delete account request has been sent"

--- a/src/unit_tests/ctx/delete_account.rs
+++ b/src/unit_tests/ctx/delete_account.rs
@@ -44,18 +44,6 @@ fn actionctx_delete_account() {
                 )
                 .boxed_env()
             }
-            Request {
-                url, method, body, ..
-            } if url == "https://api.strem.io/api/logout"
-                && method == "POST"
-                && body == "{\"type\":\"Logout\",\"authKey\":\"auth_key\"}" =>
-            {
-                future::ok(
-                    Box::new(APIResult::Ok(SuccessResponse { success: True {} }))
-                        as Box<dyn Any + Send>,
-                )
-                .boxed_env()
-            }
             _ => default_fetch_handler(request),
         }
     }
@@ -133,8 +121,8 @@ fn actionctx_delete_account() {
 
     assert_eq!(
         REQUESTS.read().unwrap().len(),
-        2,
-        "Two requests have been sent"
+        1,
+        "One request have been sent"
     );
 
     assert_eq!(
@@ -147,16 +135,5 @@ fn actionctx_delete_account() {
             ..Default::default()
         },
         "Delete account request has been sent"
-    );
-
-    assert_eq!(
-        REQUESTS.read().unwrap().get(1).unwrap().to_owned(),
-        Request {
-            url: "https://api.strem.io/api/logout".to_owned(),
-            method: "POST".to_owned(),
-            body: "{\"type\":\"Logout\",\"authKey\":\"auth_key\"}".to_owned(),
-            ..Default::default()
-        },
-        "Logout request has been sent"
     );
 }

--- a/src/unit_tests/ctx/delete_account.rs
+++ b/src/unit_tests/ctx/delete_account.rs
@@ -10,7 +10,7 @@ use crate::{
         events::DismissedEventsBucket,
         library::LibraryBucket,
         notifications::NotificationsBucket,
-        profile::{Auth, AuthKey, GDPRConsent, Profile, User},
+        profile::{Auth, AuthKey, GDPRConsent, Password, Profile, User},
         search_history::SearchHistoryBucket,
         server_urls::ServerUrlsBucket,
         streams::StreamsBucket,
@@ -110,7 +110,7 @@ fn actionctx_delete_account() {
     TestEnv::run(|| {
         runtime.dispatch(RuntimeAction {
             field: None,
-            action: Action::Ctx(ActionCtx::DeleteAccount("password".to_owned())),
+            action: Action::Ctx(ActionCtx::DeleteAccount(Password("password".to_owned()))),
         })
     });
 

--- a/src/unit_tests/ctx/mod.rs
+++ b/src/unit_tests/ctx/mod.rs
@@ -1,5 +1,6 @@
 mod add_to_library;
 mod authenticate;
+mod delete_account;
 mod install_addon;
 mod logout;
 mod update_events;


### PR DESCRIPTION
Closes https://github.com/Stremio/stremio-tasks/issues/300

Changed the handling of Logout messages, now when `CtxAction::Logout` is dispatched, it will dispatch `Internal::Logout`
https://github.com/Stremio/stremio-core/pull/753/files#diff-30ea419c3fb216cc24c692f6ccd053854151825012d9a17bf285525e276e50ffR117

This allow to pass a flag to `Internal::Logout` to tell if the session was already deleted server-side, to prevent sending a `delete_session` request, as the `delete_account` request already delete user session server-side
https://github.com/Stremio/stremio-core/pull/753/files#diff-30ea419c3fb216cc24c692f6ccd053854151825012d9a17bf285525e276e50ffR123