### PR TITLE
feat(stremio-core-web): MetaDetails - add last used stream flag to Streams

### DIFF
--- a/stremio-core-web/src/model/serialize_meta_details.rs
+++ b/stremio-core-web/src/model/serialize_meta_details.rs
@@ -44,9 +44,11 @@ mod model {
         /// Watch progress percentage
         pub progress: Option<f64>,
         pub deep_links: StreamDeepLinks,
-        /// Whether or not this is the suggested by core stream
-        /// Only 1 stream can be a suggested one!
-        pub suggested: Option<bool>,
+        /// Whether or not this is a stream the user has already played
+        /// Only 1 stream can be the last used one!
+        ///
+        /// Find out more about how we select it form the StreamsBucket in the core's model.
+        pub last_used: Option<bool>,
     }
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -191,7 +193,7 @@ pub fn serialize_meta_details<E: Env + 'static>(
                                     &ctx.profile.settings,
                                 ))
                                 .into_web_deep_links(),
-                                suggested: None,
+                                last_used: None,
                             })
                             .collect::<Vec<_>>(),
                         in_library: ctx
@@ -280,7 +282,7 @@ pub fn serialize_meta_details<E: Env + 'static>(
                                         },
                                     )
                                     .into_web_deep_links(),
-                                suggested: meta_details.suggested_stream.as_ref().and_then(
+                                last_used: meta_details.last_used_stream.as_ref().and_then(
                                     |resource| match resource.content.as_ref() {
                                         Some(Loadable::Ready(Some(suggested_stream))) => {
                                             Some(suggested_stream == stream)

--- a/stremio-core-web/src/model/serialize_meta_details.rs
+++ b/stremio-core-web/src/model/serialize_meta_details.rs
@@ -47,7 +47,7 @@ mod model {
         /// Whether or not this is a stream the user has already played
         /// Only 1 stream can be the last used one!
         ///
-        /// Find out more about how we select it form the StreamsBucket in the core's model.
+        /// Find out more about how we select it from the StreamsBucket in the core's model.
         pub last_used: Option<bool>,
     }
     #[derive(Serialize)]

--- a/stremio-core-web/src/model/serialize_meta_details.rs
+++ b/stremio-core-web/src/model/serialize_meta_details.rs
@@ -41,9 +41,12 @@ mod model {
     pub struct Stream<'a> {
         #[serde(flatten)]
         pub stream: &'a stremio_core::types::resource::Stream,
-        // Watch progress percentage
+        /// Watch progress percentage
         pub progress: Option<f64>,
         pub deep_links: StreamDeepLinks,
+        /// Whether or not this is the suggested by core stream
+        /// Only 1 stream can be a suggested one!
+        pub suggested: Option<bool>,
     }
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -188,6 +191,7 @@ pub fn serialize_meta_details<E: Env + 'static>(
                                     &ctx.profile.settings,
                                 ))
                                 .into_web_deep_links(),
+                                suggested: None,
                             })
                             .collect::<Vec<_>>(),
                         in_library: ctx
@@ -276,6 +280,15 @@ pub fn serialize_meta_details<E: Env + 'static>(
                                         },
                                     )
                                     .into_web_deep_links(),
+                                suggested: meta_details.suggested_stream.as_ref().and_then(
+                                    |resource| match resource.content.as_ref() {
+                                        Some(Loadable::Ready(Some(suggested_stream))) => {
+                                            Some(suggested_stream == stream)
+                                        }
+                                        Some(Loadable::Ready(None)) => Some(false),
+                                        _ => None,
+                                    },
+                                ),
                             })
                             .collect::<Vec<_>>(),
                     ),


### PR DESCRIPTION
Marks the latest streams previously watched on the device as `last used` for stremio-core-web MetaDetails model

- renames core's field to fit better as the name was misleading
- adds field to stremio-core-web