### PR TITLE
fix(core): stremio-serde-hex fix for panics on empty input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,8 +1203,7 @@ dependencies = [
 [[package]]
 name = "stremio-serde-hex"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5600c4d6b97a1e6b4c0a9fa6e14d94eba885f2aa7610fc52a1557a9a140e69"
+source = "git+https://github.com/Stremio/serde-hex?branch=fix/zero-sized-chunks-panic#e06baea18dc14efeeb88b6545b33238d85b9fb71"
 dependencies = [
  "array-init",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,11 @@ serde_json = "1.0.*"
 serde_path_to_error = "0.1"
 serde_url_params = "0.2"
 serde_bencode = "0.2.*"
-stremio-serde-hex = "0.1.*" # keep track of https://github.com/fspmarshall/serde-hex/pull/8
+# keep track of https://github.com/fspmarshall/serde-hex/pull/8
+# stremio-serde-hex = "0.1.*"
+# Keep track of https://github.com/fspmarshall/serde-hex/pull/19
+stremio-serde-hex = { version = "0.1.*", git = "https://github.com/Stremio/serde-hex", branch = "fix/zero-sized-chunks-panic" }
+
 serde_with = { version = "3.5", features = ["macros", "chrono_0_4"] }
 
 flate2 = "1"

--- a/src/types/torrent.rs
+++ b/src/types/torrent.rs
@@ -45,3 +45,25 @@ impl fmt::Display for InfoHash {
         f.write_str(&hex::encode(self.0))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json::{from_value, json};
+
+    #[test]
+    fn test_info_has_for_zero_sized_chunk() {
+        let empty = json!("");
+        let _err = from_value::<InfoHash>(empty).expect_err("Should error with zero size");
+
+        let prefix_only = json!("0x");
+        let _err = from_value::<InfoHash>(prefix_only).expect_err("Should error");
+
+        let valid_no_prefix = json!("df389295484b3059a4726dc6d8a57f71bb5f4c81");
+        from_value::<InfoHash>(valid_no_prefix).expect("Should be correct");
+
+        let valid_prefix = json!("df389295484b3059a4726dc6d8a57f71bb5f4c81");
+        from_value::<InfoHash>(valid_prefix).expect("Should be correct");
+    }
+}


### PR DESCRIPTION
tests have been added to confirm that panics will not occur from serde-hex