### PR TITLE
Fixing a deep link that wasn't working due to an unescaped string

### DIFF
--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -125,8 +125,11 @@ impl From<(&Stream, Option<&Url>, &Settings)> for ExternalPlayerLink {
                        ..Default::default()
                     }),
                     "iina" => Some(OpenPlayerLink {
-                        macos: Some(format!("iina://weblink?url={url}")),
-                       ..Default::default()
+                        macos: Some(format!(
+                            "iina://weblink?url={}",
+                            utf8_percent_encode(&url, URI_COMPONENT_ENCODE_SET)
+                        )),
+                        ..Default::default()
                     }),
                     "mpv" => Some(OpenPlayerLink {
                         macos: Some(format!("mpv://{url}")),


### PR DESCRIPTION
When building the IINA deep link, the URL wasn't escaped correctly, so some URLs weren't working because IINA wasn't reading the complete URL. Now the URL should be escaped correctly.
The same bug could be present in other deep link integrations.