### PR TITLE
chore: clippy & fmt

### DIFF
--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -481,7 +481,7 @@ fn supported_rating_id(id: &str) -> bool {
 }
 
 fn supported_rating_type(r#type: &str) -> bool {
-    USER_LIKES_SUPPORTED_TYPES.iter().any(|t| r#type == *t)
+    USER_LIKES_SUPPORTED_TYPES.contains(&r#type)
 }
 
 fn rating_info_update<E: Env + 'static>(

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -51,7 +51,7 @@ where
         runtime.handle_effects(effects, vec![]);
         (runtime, rx)
     }
-    pub fn model(&self) -> LockResult<RwLockReadGuard<M>> {
+    pub fn model(&self) -> LockResult<RwLockReadGuard<'_, M>> {
         self.model.read()
     }
     pub fn dispatch(&self, action: RuntimeAction<E, M>) {

--- a/src/types/addon/manifest.rs
+++ b/src/types/addon/manifest.rs
@@ -358,7 +358,7 @@ pub enum ManifestExtra {
 }
 
 impl ManifestExtra {
-    pub fn iter(&self) -> impl Iterator<Item = Cow<ExtraProp>> {
+    pub fn iter(&self) -> impl Iterator<Item = Cow<'_, ExtraProp>> {
         match &self {
             ManifestExtra::Full { props } => Either::Left(props.iter().map(Cow::Borrowed)),
             ManifestExtra::Short {

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -328,7 +328,7 @@ pub struct Video {
 }
 
 impl Video {
-    pub fn stream(&self) -> Option<Cow<Stream>> {
+    pub fn stream(&self) -> Option<Cow<'_, Stream>> {
         self.streams
             .iter()
             .exactly_one()


### PR DESCRIPTION
todo: large enum variants warning