### PR TITLE
fix: manifest - is_resource_supported now considers empty idPrefixes …

### DIFF
--- a/src/types/addon/manifest.rs
+++ b/src/types/addon/manifest.rs
@@ -136,8 +136,12 @@ impl Manifest {
                 };
                 let type_supported = types.is_some_and(|types| types.contains(&path.r#type));
                 let id_supported = id_prefixes.map_or(true, |id_prefixes| {
-                    id_prefixes.iter().any(|prefix| path.id.starts_with(prefix))
+                    // if prefixes are empty, all ids are supported
+                    id_prefixes.is_empty()
+                    // if we have prefixes, check if any match
+                        || id_prefixes.iter().any(|prefix| path.id.starts_with(prefix))
                 });
+
                 type_supported && id_supported
             }
         }


### PR DESCRIPTION
…as all are supported