### PR TITLE
fix: Enable ASS/SSA subtitle styling by default

### DIFF
--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -758,7 +758,7 @@ fn migrate_storage_schema_to_v21<E: Env>() -> TryEnvFuture<()> {
                 Some(settings) => {
                     settings.insert(
                         "assSubtitlesStyling".to_owned(),
-                        serde_json::Value::Bool(false),
+                        serde_json::Value::Bool(true),
                     );
                     E::set_storage(PROFILE_STORAGE_KEY, Some(&profile))
                 }
@@ -1530,7 +1530,7 @@ mod test {
 
             let migrated_profile = json!({
                 "settings": {
-                    "assSubtitlesStyling": false,
+                    "assSubtitlesStyling": true,
                 }
             });
 

--- a/src/types/profile/settings.rs
+++ b/src/types/profile/settings.rs
@@ -82,7 +82,7 @@ impl Default for Settings {
             subtitles_background_color: "#00000000".to_owned(),
             subtitles_outline_color: "#000000".to_owned(),
             subtitles_opacity: 100,
-            ass_subtitles_styling: false,
+            ass_subtitles_styling: true,
             esc_exit_fullscreen: true,
             seek_time_duration: 10000,
             seek_short_time_duration: 3000,

--- a/src/unit_tests/serde/default_tokens_ext.rs
+++ b/src/unit_tests/serde/default_tokens_ext.rs
@@ -432,7 +432,7 @@ impl DefaultTokens for Settings {
             Token::Str("subtitlesOpacity"),
             Token::U8(100),
             Token::Str("assSubtitlesStyling"),
-            Token::Bool(false),
+            Token::Bool(true),
             Token::Str("escExitFullscreen"),
             Token::Bool(true),
             Token::Str("seekTimeDuration"),

--- a/src/unit_tests/serde/settings.rs
+++ b/src/unit_tests/serde/settings.rs
@@ -191,7 +191,7 @@ fn settings_de() {
             Token::Str("subtitlesOpacity"),
             Token::U8(100),
             Token::Str("assSubtitlesStyling"),
-            Token::Bool(false),
+            Token::Bool(true),
             Token::Str("escExitFullscreen"),
             Token::Bool(true),
             Token::Str("seekTimeDuration"),


### PR DESCRIPTION
Fixes #910 - ASS/SSA subtitles styles were being ignored in newer versions.

Changed the default value of ass_subtitles_styling from false to true to match v4.4 behavior where subtitle styles (fonts, colors, positioning) were correctly preserved.

Changes:
- Set ass_subtitles_styling default to true in Settings
- Updated migration v21 to set assSubtitlesStyling to true
- Updated related test expectations

Testing:
- All 194 existing tests pass.