### PR TITLE
fix: Hide items from continue watching when >= 95% watched

### DIFF
--- a/src/types/library/library_item.rs
+++ b/src/types/library/library_item.rs
@@ -48,11 +48,14 @@ impl LibraryItem {
         let recently_removed = self.removed && self.mtime > year_ago;
         self.r#type != "other" && (!self.removed || recently_removed)
     }
+    const CONTINUE_WATCHING_COMPLETION_THRESHOLD: f64 = 95.0;
+
     #[inline]
     pub fn is_in_continue_watching(&self) -> bool {
-        // re-added (!self.removed || temp) check
-        // makes sure to add only relevant Library Items to the Continue Watching
-        self.r#type != "other" && (!self.removed || self.temp) && self.state.time_offset > 0
+        self.r#type != "other"
+            && (!self.removed || self.temp)
+            && self.state.time_offset > 0
+            && self.progress() < Self::CONTINUE_WATCHING_COMPLETION_THRESHOLD
     }
 
     /// Returns watch progress percentage


### PR DESCRIPTION
## Summary
Fixes #12 - Items are now removed from the continue watching section when the user has watched >= 95% of their duration.

## Changes
- [src/types/library/library_item.rs](cci:7://file:///home/anike/stremio-core/src/types/library/library_item.rs:0:0-0:0) - Added 95% progress threshold to [is_in_continue_watching()](cci:1://file:///home/anike/stremio-core/src/types/library/library_item.rs:50:4-55:5) method

## Testing
All 194 existing tests pass.