### PR TITLE
feat(core-web): expose pagination loading state in Discover serializer

### DIFF
--- a/stremio-core-web/src/model/serialize_discover.rs
+++ b/stremio-core-web/src/model/serialize_discover.rs
@@ -67,6 +67,7 @@ mod model {
         pub catalogs: Vec<SelectableCatalog<'a>>,
         pub extra: Vec<SelectableExtra<'a>>,
         pub next_page: bool,
+        pub loading_next_page: bool,
     }
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -170,6 +171,12 @@ pub fn serialize_discover(
                 })
                 .collect(),
             next_page: discover.selectable.next_page.is_some(),
+            loading_next_page: discover.catalog.len() > 1
+                && discover
+                    .catalog
+                    .last()
+                    .map(|page| matches!(&page.content, Some(Loadable::Loading) | None))
+                    .unwrap_or(false),
         },
         catalog: (!discover.catalog.is_empty()).as_option().map(|_| {
             let first_page = discover


### PR DESCRIPTION
## Summary
- Add `loadingNextPage` boolean to the serialized Discover selectable state
- True when there are 2+ catalog pages and the last page is still loading (pagination in progress)
- Gives the frontend an authoritative signal to show a loading indicator instead of relying on fragile local React state