### PR TITLE
Subtitles: add optional `label` field to Subtitles struct

### DIFF
--- a/src/types/resource/subtitles.rs
+++ b/src/types/resource/subtitles.rs
@@ -14,4 +14,6 @@ pub struct Subtitles {
         derivative(Default(value = "Url::parse(\"protocol://host\").unwrap()"))
     )]
     pub url: Url,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }

--- a/src/unit_tests/serde/subtitles.rs
+++ b/src/unit_tests/serde/subtitles.rs
@@ -9,6 +9,7 @@ fn subtitles() {
             id: "id".into(),
             lang: "lang".to_owned(),
             url: Url::parse("https://url").unwrap(),
+            label: None,
         },
         &[
             Token::Struct {
@@ -21,6 +22,34 @@ fn subtitles() {
             Token::Str("lang"),
             Token::Str("url"),
             Token::Str("https://url/"),
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
+fn subtitles_with_label() {
+    assert_tokens(
+        &Subtitles {
+            id: "id".into(),
+            lang: "eng".to_owned(),
+            url: Url::parse("https://url").unwrap(),
+            label: Some("eng #1 [opensubtitles] 1080p.BluRay".to_owned()),
+        },
+        &[
+            Token::Struct {
+                name: "Subtitles",
+                len: 4,
+            },
+            Token::Str("id"),
+            Token::Str("id"),
+            Token::Str("lang"),
+            Token::Str("eng"),
+            Token::Str("url"),
+            Token::Str("https://url/"),
+            Token::Str("label"),
+            Token::Some,
+            Token::Str("eng #1 [opensubtitles] 1080p.BluRay"),
             Token::StructEnd,
         ],
     );


### PR DESCRIPTION
## Summary

- Adds an optional `label` field to the `Subtitles` struct in `src/types/resource/subtitles.rs`
- Allows addon-provided subtitle labels to be preserved and passed through to the UI layer
- Enables users to distinguish between multiple subtitles of the same language (e.g. different sources, release types, or quality levels)

## Problem

The `Subtitles` struct currently only contains `id`, `lang`, and `url`. When addons include a `label` field on subtitle objects, it is silently dropped during deserialization. This means:

- The UI layer never receives custom subtitle labels
- Users cannot tell apart multiple subtitles of the same language
- Addon developers resort to stuffing metadata into the `lang` field, breaking language grouping

## Solution

```rust
#[serde(default, skip_serializing_if = "Option::is_none")]
pub label: Option<String>,
```

This is fully backward-compatible:
- Existing subtitles without `label` deserialize with `label: None`
- `skip_serializing_if` ensures no extra field is emitted when `label` is `None`
- The `serialize_player.rs` bridge uses `#[serde(flatten)]` on `Subtitles`, so the field automatically passes through to all platform UIs

## Related issues

- Closes #943
- Addresses #936 (Pass subtitle `label` field to the UI/view layer)
- Addresses #907 (Improve Subtitle Identification by Displaying Full Filenames)
- Related to [stremio-bugs#544](https://github.com/Stremio/stremio-bugs/issues/544) (subtitle names on Android TV)

## Test plan

- [x] Updated existing `subtitles` serde test to include `label: None`
- [x] Added new `subtitles_with_label` test verifying serialization/deserialization with a label value
- [ ] Verify that the `default_tokens_ext` still works (uses `Subtitles::default()` which defaults `label` to `None`)