### PR TITLE
feature - Add UpdateAddons to allows addons reorder

### DIFF
--- a/src/models/ctx/update_profile.rs
+++ b/src/models/ctx/update_profile.rs
@@ -131,6 +131,27 @@ pub fn update_profile<E: Env + 'static>(
                 }
             }
         },
+        Msg::Action(Action::Ctx(ActionCtx::UpdateAddons(addons))) => {
+            if profile.addons_locked {
+                return addons_update_error_effects(addons, OtherError::UserAddonsAreLocked);
+            }
+
+            if profile.addons != *addons {
+                addons.clone_into(&mut profile.addons);
+
+                let push_to_api_effects = match profile.auth_key() {
+                    Some(auth_key) => {
+                        Effects::one(push_addons_to_api::<E>(profile.addons.to_owned(), auth_key))
+                            .unchanged()
+                    }
+                    _ => Effects::none().unchanged(),
+                };
+
+                push_to_api_effects.join(Effects::msg(Msg::Internal(Internal::ProfileChanged)))
+            } else {
+                Effects::none().unchanged()
+            }
+        }
         Msg::Action(Action::Ctx(ActionCtx::InstallAddon(addon))) => {
             Effects::msg(Msg::Internal(Internal::InstallAddon(addon.to_owned()))).unchanged()
         }
@@ -589,6 +610,20 @@ fn addon_action_error_effects(error: OtherError, source: Event) -> Effects {
     Effects::msg(Msg::Event(Event::Error {
         error: CtxError::from(error),
         source: Box::new(source),
+    }))
+    .unchanged()
+}
+
+fn addons_update_error_effects(addons: &[Descriptor], error: OtherError) -> Effects {
+    Effects::msg(Msg::Event(Event::Error {
+        error: CtxError::from(error),
+        source: Box::new(Event::AddonsPushedToAPI {
+            transport_urls: addons
+                .iter()
+                .map(|addon| &addon.transport_url)
+                .cloned()
+                .collect(),
+        }),
     }))
     .unchanged()
 }

--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -82,6 +82,7 @@ pub enum ActionCtx {
     },
     PushAddonsToAPI,
     PullAddonsFromAPI,
+    UpdateAddons(Vec<Descriptor>),
     SyncLibraryWithAPI,
     /// Pull notifications for all [`LibraryItem`]s that we should pull notifications for.
     ///

--- a/src/unit_tests/ctx/mod.rs
+++ b/src/unit_tests/ctx/mod.rs
@@ -13,6 +13,7 @@ mod remove_from_library;
 mod rewind_library_item;
 mod sync_library_with_api;
 mod uninstall_addon;
+mod update_addons;
 mod update_search_history;
 mod update_settings;
 mod update_streaming_server_urls;


### PR DESCRIPTION
Adding a message action UpdateAddons in order to allows stemio-web (or the other) to update the orders.

This PR is linked to https://github.com/Stremio/stremio-web/pull/1163