### PR TITLE
perf: bump regex 1.8 -> 1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ hex = "0.4"
 anyhow = "1.0"
 thiserror = "2"
 
-regex = "1.8"
+regex = "1.11"
 
 # local search and autocomplete functionallity
 localsearch = { version = "0.1.0", git = "https://github.com/Stremio/local-search", branch = "main" }

--- a/stremio-core-web/Cargo.toml
+++ b/stremio-core-web/Cargo.toml
@@ -34,7 +34,7 @@ url = { version = "2.4.*", features = ["serde"] }
 chrono = "0.4.*"
 semver = { version = "1", features = ["serde"] }
 # used for Env impl
-regex = {version = "1.8", optional = true }
+regex = {version = "1.11", optional = true }
 # used for Env impl
 hex = { version = "0.4", optional = true }
 either = "1.6.*"


### PR DESCRIPTION
## Summary

Bumps the minimum required `regex` version from `1.8` to `1.11` in both the workspace root and `stremio-core-web`.

- `Cargo.toml:91` — `regex = "1.8"` → `"1.11"`
- `stremio-core-web/Cargo.toml:37` — `regex = {version = "1.8", optional = true }` → `"1.11"`

## Why this change

`regex 1.9`–`1.11` landed NFA/DFA engine work and SIMD acceleration. On the patterns stremio-core uses (ASCII path parsers and simple prefix matches) the throughput gain is modest — this is primarily a **hygiene fix**: the manifest floor now matches reality (`Cargo.lock` was already resolved at `1.11.0`), so a future `cargo update` won't surprise-downgrade to 1.8.x and reintroduce old bugfix gaps.

## Effect

- No behavior change — `Cargo.lock` already pinned `1.11.0`, so the transitive tree is identical.
- Future perf-oriented patches land automatically.
- Reduces surface area for version-skew bugs between contributors.

## Behavior risk audit

Only two first-party `regex::Regex::new(...)` callsites exist:
- `src/deep_links/mod.rs:116` — `Regex::new(r"https?://")` — pure ASCII literal.
- `stremio-core-web/src/env.rs:57` — `Regex::new(r"^/player/([^/]*)(?:/([^/]*)/([^/]*)/([^/]*)/([^/]*)/([^/]*))?$")` — anchored ASCII path parser with plain capture groups.

Neither pattern uses Unicode classes, look-around, or empty-match-sensitive constructs where 1.9+ semantics diverge. Magnet URL parsing in `src/types/resource/stream.rs` uses the `magnet_url` crate (not `regex`), so that path is unaffected.

## Test plan

Verified locally on Windows 11 with `rustc 1.95.0 stable-x86_64-pc-windows-gnu`:

- [x] `cargo test -p stremio-core --lib` — **202 passed, 0 failed**
- [x] `cargo clippy -p stremio-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Full-workspace build (including `stremio-core-web`) requires the `wasm-bindgen` upgrade in #969 because `wasm-bindgen 0.2.78` is incompatible with current Rust.