### PR TITLE
chore: remove unmaintained boolinator dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,12 +102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boolinator"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,7 +1101,6 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "base64 0.22.1",
- "boolinator",
  "chrono",
  "data-encoding",
  "derivative",
@@ -1154,7 +1147,6 @@ dependencies = [
 name = "stremio-core-web"
 version = "0.51.1"
 dependencies = [
- "boolinator",
  "chrono",
  "console_error_panic_hook",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ either = "1.6"
 enclose = "1.1"
 derivative = "2.2"
 derive_more = { version = "2", features = ["from", "into", "into_iterator", "try_into", "deref"] }
-boolinator = "2.4"
 strum = { version = "0.27", features = ["derive"] }
 
 lazysort = "0.2"

--- a/src/models/catalog_with_filters.rs
+++ b/src/models/catalog_with_filters.rs
@@ -12,7 +12,6 @@ use crate::types::addon::{
 };
 use crate::types::profile::Profile;
 use crate::types::resource::MetaItemPreview;
-use boolinator::Boolinator;
 use derivative::Derivative;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -419,8 +418,7 @@ fn selectable_update<T: CatalogResourceAdapter>(
                 .map(|extra_prop| {
                     let none_option =
                         (!extra_prop.is_required)
-                            .as_option()
-                            .map(|_| SelectableExtraOption {
+                            .then(|| SelectableExtraOption {
                                 value: None,
                                 selected: selected
                                     .request

--- a/src/models/catalog_with_filters.rs
+++ b/src/models/catalog_with_filters.rs
@@ -416,31 +416,29 @@ fn selectable_update<T: CatalogResourceAdapter>(
                     extra_prop.name != SKIP_EXTRA_PROP.name && !extra_prop.options.is_empty()
                 })
                 .map(|extra_prop| {
-                    let none_option =
-                        (!extra_prop.is_required)
-                            .then(|| SelectableExtraOption {
-                                value: None,
-                                selected: selected
+                    let none_option = (!extra_prop.is_required).then(|| SelectableExtraOption {
+                        value: None,
+                        selected: selected
+                            .request
+                            .path
+                            .extra
+                            .iter()
+                            .all(|extra_value| extra_value.name != extra_prop.name),
+                        request: ResourceRequest {
+                            base: selected.request.base.to_owned(),
+                            path: ResourcePath {
+                                id: manifest_catalog.id.to_owned(),
+                                r#type: manifest_catalog.r#type.to_owned(),
+                                resource: selected.request.path.resource.to_owned(),
+                                extra: selected
                                     .request
                                     .path
                                     .extra
-                                    .iter()
-                                    .all(|extra_value| extra_value.name != extra_prop.name),
-                                request: ResourceRequest {
-                                    base: selected.request.base.to_owned(),
-                                    path: ResourcePath {
-                                        id: manifest_catalog.id.to_owned(),
-                                        r#type: manifest_catalog.r#type.to_owned(),
-                                        resource: selected.request.path.resource.to_owned(),
-                                        extra: selected
-                                            .request
-                                            .path
-                                            .extra
-                                            .to_owned()
-                                            .extend_one(&extra_prop, None),
-                                    },
-                                },
-                            });
+                                    .to_owned()
+                                    .extend_one(&extra_prop, None),
+                            },
+                        },
+                    });
                     let options = extra_prop
                         .options
                         .iter()

--- a/src/types/resource/stream.rs
+++ b/src/types/resource/stream.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, io::Write};
 use tracing::trace;
 
 use base64::Engine;
-use boolinator::Boolinator;
 use flate2::{
     write::{ZlibDecoder, ZlibEncoder},
     Compression,
@@ -117,9 +116,9 @@ impl Stream {
     pub fn youtube(video_id: &str) -> Option<Self> {
         video_id
             .starts_with(YOUTUBE_ADDON_ID_PREFIX)
-            .as_option()
             // video id is in format: yt_id:YT_CHANNEL_ID:YT_VIDEO_ID
-            .and_then(|_| video_id.split(':').nth(2))
+            .then(|| video_id.split(':').nth(2))
+            .flatten()
             .map(|yt_id| Self {
                 source: StreamSource::YouTube {
                     yt_id: yt_id.to_owned(),

--- a/stremio-core-web/Cargo.toml
+++ b/stremio-core-web/Cargo.toml
@@ -40,7 +40,6 @@ hex = { version = "0.4", optional = true }
 either = "1.6.*"
 enclose = "1.1.*"
 itertools = "0.14.*"
-boolinator = "2.4.*"
 
 # WASM
 wasm-bindgen = { version = "=0.2.78", features = ["serde-serialize"], optional = true }

--- a/stremio-core-web/src/model/serialize_discover.rs
+++ b/stremio-core-web/src/model/serialize_discover.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "wasm")]
 use {
     crate::model::deep_links_ext::DeepLinksExt,
-    boolinator::Boolinator,
     gloo_utils::format::JsValueSerdeExt,
     itertools::Itertools,
     stremio_core::deep_links::{DiscoverDeepLinks, MetaItemDeepLinks, StreamDeepLinks},
@@ -171,7 +170,7 @@ pub fn serialize_discover(
                 .collect(),
             next_page: discover.selectable.next_page.is_some(),
         },
-        catalog: (!discover.catalog.is_empty()).as_option().map(|_| {
+        catalog: (!discover.catalog.is_empty()).then(|| {
             let first_page = discover
                 .catalog
                 .first()


### PR DESCRIPTION
## Summary

Remove the `boolinator` crate (unmaintained since 2016 — last release August 2016) from the workspace. Replace its `Boolinator::as_option` / `as_some` extension methods on `bool` with stdlib equivalents (`bool::then`, `bool::then_some`).

## Why this change

- `boolinator` is unmaintained (no commits in 9+ years); `rustsec` has flagged it as a stale dependency in the past.
- `bool::then` (stable since Rust 1.50, May 2021) and `bool::then_some` (stable since Rust 1.62, June 2022) cover every call site. No third-party dep needed.
- Shrinks the dependency graph by one crate; `Cargo.lock` no longer resolves `boolinator 2.4.0`.

## Effect

- **One fewer transitive dependency**: slightly faster clean builds, fewer vectors for supply-chain staleness alerts.
- **No behavior change**: the replacements are semantically identical. `bool::then(F)` returns `Some(F())` when true; `as_option(x)` returned `Some(x)` when true — equivalent except `then` accepts a closure so side-effectful arguments only execute on the truthy branch (never the case here).
- **No public API / no serialized-shape / no wire-format changes.** This is an internal refactor only.

## Call sites updated

- `src/models/catalog_with_filters.rs` — `(!extra_prop.is_required).as_option().map(|_| SelectableExtraOption { .. })` → `(!extra_prop.is_required).then(|| SelectableExtraOption { .. })`
- `src/types/resource/stream.rs` (`Stream::youtube`) — `cond.as_option().and_then(|_| split)` → `cond.then(|| split).flatten()`
- `stremio-core-web/src/model/serialize_discover.rs` — `(!discover.catalog.is_empty()).as_option().map(|_| ..)` → `.then(|| ..)`

Manifest changes:
- `Cargo.toml` — drop `boolinator = "2.4"`
- `stremio-core-web/Cargo.toml` — drop `boolinator = "2.4.*"`
- `Cargo.lock` — regenerated (removes the `boolinator` entry)

## Test plan

Verified locally on Windows 11 with `rustc 1.95.0 stable-x86_64-pc-windows-gnu`:

- [x] `cargo test -p stremio-core --lib` — **202 passed, 0 failed**
- [x] `cargo clippy -p stremio-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean (fixup commit `082e3f63f` applies the formatting that `cargo fmt` requested after the `.then(..)` rewrite)

Full-workspace build (including `stremio-core-web`) needs the `wasm-bindgen` upgrade in #969 because `wasm-bindgen 0.2.78` is incompatible with current Rust.