### PR TITLE
build: bump workspace MSRV from 1.77 to 1.85

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_MSRV_VERSION: '1.77'
+  RUST_MSRV_VERSION: '1.85'
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Smart Code OOD"]
 edition = "2021"
 
-# When upgrading MSRV make sure to update the msrv.yaml workflow
-rust-version = "1.77"
+# When upgrading MSRV make sure to update the msrv.yml workflow
+rust-version = "1.85"
 
 [profile.release]
 lto = true

--- a/stremio-watched-bitfield/Cargo.toml
+++ b/stremio-watched-bitfield/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# because of `dep:serde` supported after 1.60
-rust-version = "1.60"
+# Aligned with the workspace MSRV. Originally pinned at 1.60 for `dep:serde`
+# syntax; raising to 1.85 keeps all three crates on one Rust version.
+rust-version = "1.85"
 
 [lib]
 doctest = false


### PR DESCRIPTION
## Summary

Aligns the declared minimum supported Rust version (MSRV) across the three workspace crates and the MSRV CI job to `1.85` (up from `1.77` on the two core crates and `1.60` on `stremio-watched-bitfield`).

## Why this change

- **`build.yml` already uses stable Rust** and the workspace compiles fine on current toolchains after this bump — the `1.77` declaration on the manifest was lagging reality.
- **`stremio-watched-bitfield` pinned `1.60`** with a note about `dep:serde` syntax (stable since 1.60). That rationale is still true, but keeping the watched-bitfield floor three years behind the rest of the workspace created a split MSRV with no practical benefit.
- **Downstream blockers**: several upcoming cleanups in the workspace (migrating `once_cell::sync::Lazy` → `std::sync::LazyLock`, stabilized in 1.80) require the MSRV to be at least 1.80. 1.85 matches the CI matrix and leaves headroom.

## Effect

- **Consumers pinning older Rust can no longer build the library.** The effective minimum was already `1.77`, so this affects users on `1.77`–`1.84`. `1.85.1` is approximately one year old on release day of this PR.
- **Unlocks future PRs** to drop `once_cell` in favor of standard library primitives, tighten type inference in a few spots, and use 1.80+ stdlib additions.
- **No runtime behavior change.** This PR changes declared metadata and a CI env var only — the compiled binaries are identical.

## Changes

- `Cargo.toml` — `rust-version = "1.77"` → `"1.85"`. Also fixes a comment that referenced a non-existent workflow filename (`msrv.yaml` → `msrv.yml`).
- `stremio-watched-bitfield/Cargo.toml` — `rust-version = "1.60"` → `"1.85"`. Comment rewritten to explain the alignment rationale.
- `.github/workflows/msrv.yml` — `RUST_MSRV_VERSION: '1.77'` → `'1.85'`.

**No `Cargo.lock` changes.** Dependency manifest floors are untouched; running `cargo update` is intentionally deferred to a separate PR, since the workspace has byte-exact `flate2`-encoded deep-link tests that break on any `miniz_oxide` bump (a known brittleness that deserves its own fix, not a bundled one).

## Test plan

Verified locally (Rust 1.85.1 `stable-x86_64-pc-windows-gnu`):

- [x] `cargo test -p stremio-core --lib` — **202 passed, 0 failed**
- [x] `cargo test -p stremio-watched-bitfield` — **7 passed, 0 failed**
- [x] `cargo clippy --all --no-deps -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Follow-ups (separate PRs)

- `cargo update` to pick up recent dependency patches, paired with a round-trip test for `Stream::deep_link` so the result isn't coupled to a specific `miniz_oxide` output.
- Migrate `once_cell::sync::{Lazy, OnceCell}` → `std::sync::{LazyLock, OnceLock}`, now unblocked.
- Base64 API upgrade in `stremio-watched-bitfield` (0.13 → 0.22) — real API migration, deserves its own PR.