### PR TITLE
test: replace tokio-current-thread alpha with tokio LocalSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -142,12 +142,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -173,7 +167,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen",
 ]
 
@@ -198,26 +192,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
-dependencies = [
- "cfg-if 0.1.10",
- "lazy_static",
+ "cfg-if",
 ]
 
 [[package]]
@@ -503,7 +478,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi",
@@ -1054,7 +1029,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -1065,7 +1040,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -1145,7 +1120,6 @@ dependencies = [
  "strum",
  "thiserror",
  "tokio",
- "tokio-current-thread",
  "tracing",
  "url",
 ]
@@ -1301,7 +1275,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -1361,22 +1335,6 @@ dependencies = [
  "pin-project-lite",
  "tokio-macros",
 ]
-
-[[package]]
-name = "tokio-current-thread"
-version = "0.2.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed30983efe64aa01758777622d70f45054802d959f02b7895b7245883699487"
-dependencies = [
- "crossbeam-channel",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.2.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0937fcedb52baa1424b7483977ec1e387a75413c12abc232c3c092ed35f68d"
 
 [[package]]
 name = "tokio-macros"
@@ -1522,7 +1480,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -1549,7 +1507,7 @@ version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,6 @@ lz-str = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1.12", features = ["rt", "macros"] }
-tokio-current-thread = "=0.2.0-alpha.1"
 serde_test = "1.0"
 assert_matches = "1.5"
 pretty_assertions = "1"

--- a/src/unit_tests/env.rs
+++ b/src/unit_tests/env.rs
@@ -69,16 +69,27 @@ impl TestEnv {
         env_mutex
     }
     pub fn run<F: FnOnce()>(runnable: F) {
-        tokio_current_thread::block_on_all(future::lazy(|_| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, async move {
             runnable();
-        }))
+        });
+        rt.block_on(local);
     }
     pub fn run_with_runtime<M: Model<TestEnv> + Clone + Send + Sync + 'static, F: FnOnce()>(
         rx: Receiver<RuntimeEvent<TestEnv, M>>,
         runtime: Arc<RwLock<Runtime<TestEnv, M>>>,
         runnable: F,
     ) {
-        tokio_current_thread::block_on_all(future::lazy(|_| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        let phase1 = tokio::task::LocalSet::new();
+        phase1.block_on(&rt, async {
             {
                 let runtime = runtime.read().expect("runtime read failed");
                 let state = runtime.model().expect("model read failed");
@@ -86,8 +97,10 @@ impl TestEnv {
                 states.push(Box::new(state.to_owned()) as Box<dyn Any + Send + Sync>);
             }
             runnable();
-        }));
-        tokio_current_thread::block_on_all(future::lazy(|_| {
+        });
+        rt.block_on(phase1);
+        let phase2 = tokio::task::LocalSet::new();
+        phase2.block_on(&rt, async {
             TestEnv::exec_concurrent(rx.for_each(move |event| {
                 if let RuntimeEvent::NewState(_, state) = &event {
                     let mut states = STATES.write().expect("states write failed");
@@ -101,7 +114,8 @@ impl TestEnv {
                 let mut runtime = runtime.write().expect("runtime read failed");
                 runtime.close().await.unwrap();
             }));
-        }));
+        });
+        rt.block_on(phase2);
     }
 }
 
@@ -138,10 +152,10 @@ impl Env for TestEnv {
         future::ok(()).boxed_env()
     }
     fn exec_concurrent<F: Future<Output = ()> + 'static>(future: F) {
-        tokio_current_thread::spawn(future);
+        tokio::task::spawn_local(future);
     }
     fn exec_sequential<F: Future<Output = ()> + 'static>(future: F) {
-        tokio_current_thread::spawn(future);
+        tokio::task::spawn_local(future);
     }
     fn now() -> DateTime<Utc> {
         *NOW.read().unwrap()


### PR DESCRIPTION
## Summary

Replaces the deprecated `tokio-current-thread = "=0.2.0-alpha.1"` dev-dep with `tokio::task::LocalSet` from the stable `tokio` crate already in the workspace.

## Why this change

`tokio-current-thread` is a pre-1.0 tokio crate — its final release is an **alpha from 2018**. It has been effectively abandoned for ~8 years, yet the pin `=0.2.0-alpha.1` carried forward because the test harness (`src/unit_tests/env.rs`) needed a single-threaded executor that could drain `!Send` futures before returning.

Modern tokio provides exactly that capability via `tokio::task::LocalSet`. Migrating removes a zombie dep, keeps the toolchain on supported crates, and shrinks the transitive dev-dep graph (no more `tokio-executor`, `crossbeam-channel`, `crossbeam-utils`, `cfg-if` pulled in transitively through this path).

## Effect

- **One fewer abandoned dependency** in the dev-dep graph.
- **Shrinks `Cargo.lock`** by 4 transitive entries (~60 line removal).
- **No runtime behavior change** in the published library; this is test infrastructure only. Test semantics (spawn-then-drain, two-phase state + event-loop separation) are preserved.
- **Unblocks** modernizing the Env trait's concurrency docs to reference `spawn_local` directly.

## Changes

### `src/unit_tests/env.rs`

Two public helpers in the `TestEnv` harness:

- `TestEnv::run(runnable)` — previously `tokio_current_thread::block_on_all(future::lazy(|_| runnable()))`. Now builds a current-thread tokio runtime + `LocalSet`, runs the closure inside `local.block_on`, then drives the `LocalSet` to completion with `rt.block_on(local)`. That last call preserves the key `block_on_all` semantic: spawned `!Send` futures finish before `run` returns.

- `TestEnv::run_with_runtime(rx, runtime, runnable)` — originally two successive `block_on_all` calls. Now two successive `LocalSet::block_on` + `rt.block_on(local)` pairs named `phase1` / `phase2`, preserving the original contract that Phase 1 (state capture + runnable + any effects it spawns) drains fully before Phase 2 (event collection + runtime close) starts.

Env impl:

- `exec_concurrent` / `exec_sequential`: `tokio_current_thread::spawn(future)` → `tokio::task::spawn_local(future)`. Every call site is (still) reached from within a `LocalSet::block_on` frame, which is the contract `spawn_local` expects.

### `Cargo.toml`

- Dropped `tokio-current-thread = "=0.2.0-alpha.1"` from `[dev-dependencies]`. The workspace's existing `tokio = { version = "1.12", features = ["rt", "macros"] }` already provides `LocalSet` and `spawn_local`.

### `Cargo.lock`

Regenerated: removes `tokio-current-thread`, `tokio-executor`, `crossbeam-channel`, `crossbeam-utils`, and the `cfg-if` copy they pulled in.

## Public API / contract

Zero changes to:
- Storage keys (`src/constants.rs:10`)
- WASM exports (`stremio-core-web/src/stremio_core_web.rs:83-348`)
- `Msg` / `Action` / `Event` variants
- Deep-link URL grammar
- Serialized JSON field names

## Test plan

Verified locally (Rust 1.85.1 `stable-x86_64-pc-windows-gnu`):

- [x] `cargo test -p stremio-core --lib` — **202 passed, 0 failed**
- [x] `cargo test -p stremio-watched-bitfield` — **7 passed, 0 failed**
- [x] `cargo clippy --all --no-deps -- -D warnings` — clean (the remaining `future-incompat-report` note is about `wasm-bindgen 0.2.78`; that's what #969 upgrades)
- [x] `cargo fmt --check` — clean