### PR TITLE
test: insta snapshot tripwire for persisted-storage JSON shapes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,17 +148,28 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys",
 ]
 
 [[package]]
@@ -351,6 +356,12 @@ name = "enclose"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1056f553da426e9c025a662efa48b52e62e0a3a7648aa2d15aeaaf7f0d329357"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -626,6 +637,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +690,12 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "localsearch"
@@ -1086,6 +1116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1154,7 @@ dependencies = [
  "futures",
  "hex",
  "http",
+ "insta",
  "itertools",
  "lazysort",
  "localsearch",
@@ -1623,6 +1660,21 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,4 @@ tokio-current-thread = "=0.2.0-alpha.1"
 serde_test = "1.0"
 assert_matches = "1.5"
 pretty_assertions = "1"
+insta = { version = "1", features = ["json"] }

--- a/src/unit_tests/mod.rs
+++ b/src/unit_tests/mod.rs
@@ -10,4 +10,5 @@ mod link;
 mod meta_details;
 mod player;
 mod serde;
+mod snapshots;
 mod streaming_server;

--- a/src/unit_tests/snapshots.rs
+++ b/src/unit_tests/snapshots.rs
@@ -1,0 +1,91 @@
+//! Public-contract tripwire.
+//!
+//! These snapshots fix the **serialized JSON shape** of every bucket that
+//! `stremio-core` writes to persistent storage. The storage keys themselves
+//! are declared `pub const` in [`crate::constants`] and are installed on
+//! end-user devices; any rename or schema change breaks existing installs
+//! silently. The snapshots here make such a change impossible to land
+//! without a visible `cargo insta review` diff, forcing a deliberate
+//! migration story rather than a surprise drop.
+//!
+//! To update a snapshot intentionally: run `cargo insta review`,
+//! inspect the diff, accept it, and include the `.snap` change in the
+//! same PR as the schema change (paired with a migration step in
+//! [`crate::runtime::env`] if the wire format is not backward-compatible).
+//!
+//! What's covered here:
+//! - Default `Profile` serialization (the `profile` storage key).
+//! - Empty bucket types for the remaining storage keys, as declared in
+//!   [`crate::constants`]:
+//!   `library`, `library_recent`, `streams`, `search_history`,
+//!   `streaming_server_urls`, `notifications`, `calendar`,
+//!   `dismissed_events`.
+//!
+//! What's intentionally NOT covered (deliberate scope limit):
+//! - Every [`crate::runtime::msg`] variant — the `Msg` JSON shape is
+//!   dispatch-internal, not persisted to storage; its stability matters
+//!   for live clients but not for long-term data compatibility.
+//! - Deep-link URLs — already covered semantically by
+//!   [`crate::unit_tests::deep_links::helpers::assert_player_url`] and the
+//!   ordinary `assert_eq!` checks in the deep-link tests.
+
+use insta::assert_json_snapshot;
+
+use crate::types::events::DismissedEventsBucket;
+use crate::types::library::LibraryBucket;
+use crate::types::notifications::NotificationsBucket;
+use crate::types::profile::Profile;
+use crate::types::search_history::SearchHistoryBucket;
+use crate::types::server_urls::ServerUrlsBucket;
+use crate::types::streams::StreamsBucket;
+
+/// Default `Profile` — the seed state for a fresh install. Covers the
+/// `profile` storage key at [`crate::constants::PROFILE_STORAGE_KEY`].
+#[test]
+fn snapshot_profile_default() {
+    assert_json_snapshot!(Profile::default());
+}
+
+/// Empty `LibraryBucket` — covers both the `library` and `library_recent`
+/// storage keys (same wire shape, split by recency of access).
+#[test]
+fn snapshot_library_bucket_empty() {
+    assert_json_snapshot!(LibraryBucket::default());
+}
+
+/// Empty `StreamsBucket` — covers [`crate::constants::STREAMS_STORAGE_KEY`].
+#[test]
+fn snapshot_streams_bucket_empty() {
+    assert_json_snapshot!(StreamsBucket::default());
+}
+
+/// Empty `SearchHistoryBucket` — covers
+/// [`crate::constants::SEARCH_HISTORY_STORAGE_KEY`].
+#[test]
+fn snapshot_search_history_bucket_empty() {
+    assert_json_snapshot!(SearchHistoryBucket::default());
+}
+
+/// Empty `ServerUrlsBucket` — covers
+/// [`crate::constants::STREAMING_SERVER_URLS_STORAGE_KEY`].
+#[test]
+fn snapshot_server_urls_bucket_empty() {
+    // The bucket's `new::<E>()` is parameterized on Env; default() is
+    // the neutral construction path and is what the ctx storage layer
+    // falls through to on a fresh install.
+    assert_json_snapshot!(ServerUrlsBucket::default());
+}
+
+/// Empty `NotificationsBucket` — covers
+/// [`crate::constants::NOTIFICATIONS_STORAGE_KEY`].
+#[test]
+fn snapshot_notifications_bucket_empty() {
+    assert_json_snapshot!(NotificationsBucket::default());
+}
+
+/// Empty `DismissedEventsBucket` — covers
+/// [`crate::constants::DISMISSED_EVENTS_STORAGE_KEY`].
+#[test]
+fn snapshot_dismissed_events_bucket_empty() {
+    assert_json_snapshot!(DismissedEventsBucket::default());
+}

--- a/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_dismissed_events_bucket_empty.snap
+++ b/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_dismissed_events_bucket_empty.snap
@@ -1,0 +1,9 @@
+---
+source: src/unit_tests/snapshots.rs
+expression: "DismissedEventsBucket::default()"
+snapshot_kind: text
+---
+{
+  "uid": null,
+  "items": {}
+}

--- a/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_library_bucket_empty.snap
+++ b/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_library_bucket_empty.snap
@@ -1,0 +1,9 @@
+---
+source: src/unit_tests/snapshots.rs
+expression: "LibraryBucket::default()"
+snapshot_kind: text
+---
+{
+  "uid": null,
+  "items": {}
+}

--- a/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_notifications_bucket_empty.snap
+++ b/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_notifications_bucket_empty.snap
@@ -1,0 +1,11 @@
+---
+source: src/unit_tests/snapshots.rs
+expression: "NotificationsBucket::default()"
+snapshot_kind: text
+---
+{
+  "uid": null,
+  "items": {},
+  "lastUpdated": null,
+  "created": "1970-01-01T00:00:00Z"
+}

--- a/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_profile_default.snap
+++ b/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_profile_default.snap
@@ -1,0 +1,838 @@
+---
+source: src/unit_tests/snapshots.rs
+expression: "Profile::default()"
+snapshot_kind: text
+---
+{
+  "auth": null,
+  "addons": [
+    {
+      "manifest": {
+        "id": "com.linvo.cinemeta",
+        "version": "3.0.14",
+        "name": "Cinemeta",
+        "contactEmail": null,
+        "description": "The official addon for movie and series catalogs",
+        "logo": null,
+        "background": null,
+        "types": [
+          "movie",
+          "series"
+        ],
+        "resources": [
+          "catalog",
+          "meta",
+          "addon_catalog"
+        ],
+        "idPrefixes": [
+          "tt"
+        ],
+        "catalogs": [
+          {
+            "id": "top",
+            "type": "movie",
+            "name": "Popular",
+            "extra": [
+              {
+                "name": "genre",
+                "isRequired": false,
+                "options": [
+                  "Action",
+                  "Adventure",
+                  "Animation",
+                  "Biography",
+                  "Comedy",
+                  "Crime",
+                  "Documentary",
+                  "Drama",
+                  "Family",
+                  "Fantasy",
+                  "History",
+                  "Horror",
+                  "Mystery",
+                  "Romance",
+                  "Sci-Fi",
+                  "Sport",
+                  "Thriller",
+                  "War",
+                  "Western"
+                ],
+                "optionsLimit": 1
+              },
+              {
+                "name": "search",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              },
+              {
+                "name": "skip",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              }
+            ]
+          },
+          {
+            "id": "top",
+            "type": "series",
+            "name": "Popular",
+            "extra": [
+              {
+                "name": "genre",
+                "isRequired": false,
+                "options": [
+                  "Action",
+                  "Adventure",
+                  "Animation",
+                  "Biography",
+                  "Comedy",
+                  "Crime",
+                  "Documentary",
+                  "Drama",
+                  "Family",
+                  "Fantasy",
+                  "History",
+                  "Horror",
+                  "Mystery",
+                  "Romance",
+                  "Sci-Fi",
+                  "Sport",
+                  "Thriller",
+                  "War",
+                  "Western",
+                  "Reality-TV",
+                  "Talk-Show",
+                  "Game-Show"
+                ],
+                "optionsLimit": 1
+              },
+              {
+                "name": "search",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              },
+              {
+                "name": "skip",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              }
+            ]
+          },
+          {
+            "id": "year",
+            "type": "movie",
+            "name": "New",
+            "extra": [
+              {
+                "name": "genre",
+                "isRequired": true,
+                "options": [
+                  "2026",
+                  "2025",
+                  "2024",
+                  "2023",
+                  "2022",
+                  "2021",
+                  "2020",
+                  "2019",
+                  "2018",
+                  "2017",
+                  "2016",
+                  "2015",
+                  "2014",
+                  "2013",
+                  "2012",
+                  "2011",
+                  "2010",
+                  "2009",
+                  "2008",
+                  "2007",
+                  "2006",
+                  "2005",
+                  "2004",
+                  "2003",
+                  "2002",
+                  "2001",
+                  "2000",
+                  "1999",
+                  "1998",
+                  "1997",
+                  "1996",
+                  "1995",
+                  "1994",
+                  "1993",
+                  "1992",
+                  "1991",
+                  "1990",
+                  "1989",
+                  "1988",
+                  "1987",
+                  "1986",
+                  "1985",
+                  "1984",
+                  "1983",
+                  "1982",
+                  "1981",
+                  "1980",
+                  "1979",
+                  "1978",
+                  "1977",
+                  "1976",
+                  "1975",
+                  "1974",
+                  "1973",
+                  "1972",
+                  "1971",
+                  "1970",
+                  "1969",
+                  "1968",
+                  "1967",
+                  "1966",
+                  "1965",
+                  "1964",
+                  "1963",
+                  "1962",
+                  "1961",
+                  "1960",
+                  "1959",
+                  "1958",
+                  "1957",
+                  "1956",
+                  "1955",
+                  "1954",
+                  "1953",
+                  "1952",
+                  "1951",
+                  "1950",
+                  "1949",
+                  "1948",
+                  "1947",
+                  "1946",
+                  "1945",
+                  "1944",
+                  "1943",
+                  "1942",
+                  "1941",
+                  "1940",
+                  "1939",
+                  "1938",
+                  "1937",
+                  "1936",
+                  "1935",
+                  "1934",
+                  "1933",
+                  "1932",
+                  "1931",
+                  "1930",
+                  "1929",
+                  "1928",
+                  "1927",
+                  "1926",
+                  "1925",
+                  "1924",
+                  "1923",
+                  "1922",
+                  "1921",
+                  "1920"
+                ],
+                "optionsLimit": 1
+              },
+              {
+                "name": "skip",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              }
+            ]
+          },
+          {
+            "id": "year",
+            "type": "series",
+            "name": "New",
+            "extra": [
+              {
+                "name": "genre",
+                "isRequired": true,
+                "options": [
+                  "2026",
+                  "2025",
+                  "2024",
+                  "2023",
+                  "2022",
+                  "2021",
+                  "2020",
+                  "2019",
+                  "2018",
+                  "2017",
+                  "2016",
+                  "2015",
+                  "2014",
+                  "2013",
+                  "2012",
+                  "2011",
+                  "2010",
+                  "2009",
+                  "2008",
+                  "2007",
+                  "2006",
+                  "2005",
+                  "2004",
+                  "2003",
+                  "2002",
+                  "2001",
+                  "2000",
+                  "1999",
+                  "1998",
+                  "1997",
+                  "1996",
+                  "1995",
+                  "1994",
+                  "1993",
+                  "1992",
+                  "1991",
+                  "1990",
+                  "1989",
+                  "1988",
+                  "1987",
+                  "1986",
+                  "1985",
+                  "1984",
+                  "1983",
+                  "1982",
+                  "1981",
+                  "1980",
+                  "1979",
+                  "1978",
+                  "1977",
+                  "1976",
+                  "1975",
+                  "1974",
+                  "1973",
+                  "1972",
+                  "1971",
+                  "1970",
+                  "1969",
+                  "1968",
+                  "1967",
+                  "1966",
+                  "1965",
+                  "1964",
+                  "1963",
+                  "1962",
+                  "1961",
+                  "1960"
+                ],
+                "optionsLimit": 1
+              },
+              {
+                "name": "skip",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              }
+            ]
+          },
+          {
+            "id": "imdbRating",
+            "type": "movie",
+            "name": "Featured",
+            "extra": [
+              {
+                "name": "genre",
+                "isRequired": false,
+                "options": [
+                  "Action",
+                  "Adventure",
+                  "Animation",
+                  "Biography",
+                  "Comedy",
+                  "Crime",
+                  "Documentary",
+                  "Drama",
+                  "Family",
+                  "Fantasy",
+                  "History",
+                  "Horror",
+                  "Mystery",
+                  "Romance",
+                  "Sci-Fi",
+                  "Sport",
+                  "Thriller",
+                  "War",
+                  "Western"
+                ],
+                "optionsLimit": 1
+              },
+              {
+                "name": "skip",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              }
+            ]
+          },
+          {
+            "id": "imdbRating",
+            "type": "series",
+            "name": "Featured",
+            "extra": [
+              {
+                "name": "genre",
+                "isRequired": false,
+                "options": [
+                  "Action",
+                  "Adventure",
+                  "Animation",
+                  "Biography",
+                  "Comedy",
+                  "Crime",
+                  "Documentary",
+                  "Drama",
+                  "Family",
+                  "Fantasy",
+                  "History",
+                  "Horror",
+                  "Mystery",
+                  "Romance",
+                  "Sci-Fi",
+                  "Sport",
+                  "Thriller",
+                  "War",
+                  "Western",
+                  "Reality-TV",
+                  "Talk-Show",
+                  "Game-Show"
+                ],
+                "optionsLimit": 1
+              },
+              {
+                "name": "skip",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              }
+            ]
+          },
+          {
+            "id": "last-videos",
+            "type": "series",
+            "name": "Last videos",
+            "extra": [
+              {
+                "name": "lastVideosIds",
+                "isRequired": true,
+                "options": [],
+                "optionsLimit": 100
+              }
+            ]
+          },
+          {
+            "id": "calendar-videos",
+            "type": "series",
+            "name": "Calendar videos",
+            "extra": [
+              {
+                "name": "calendarVideosIds",
+                "isRequired": true,
+                "options": [],
+                "optionsLimit": 100
+              }
+            ]
+          }
+        ],
+        "addonCatalogs": [
+          {
+            "id": "official",
+            "type": "all",
+            "name": "Official",
+            "extraRequired": [],
+            "extraSupported": []
+          },
+          {
+            "id": "official",
+            "type": "movie",
+            "name": "Official",
+            "extraRequired": [],
+            "extraSupported": []
+          },
+          {
+            "id": "official",
+            "type": "series",
+            "name": "Official",
+            "extraRequired": [],
+            "extraSupported": []
+          },
+          {
+            "id": "official",
+            "type": "channel",
+            "name": "Official",
+            "extraRequired": [],
+            "extraSupported": []
+          },
+          {
+            "id": "community",
+            "type": "all",
+            "name": "Community",
+            "extraRequired": [],
+            "extraSupported": []
+          },
+          {
+            "id": "community",
+            "type": "movie",
+            "name": "Community",
+            "extraRequired": [],
+            "extraSupported": []
+          },
+          {
+            "id": "community",
+            "type": "series",
+            "name": "Community",
+            "extraRequired": [],
+            "extraSupported": []
+          },
+          {
+            "id": "community",
+            "type": "channel",
+            "name": "Community",
+            "extraRequired": [],
+            "extraSupported": []
+          },
+          {
+            "id": "community",
+            "type": "tv",
+            "name": "Community",
+            "extraRequired": [],
+            "extraSupported": []
+          },
+          {
+            "id": "community",
+            "type": "Podcasts",
+            "name": "Community",
+            "extraRequired": [],
+            "extraSupported": []
+          },
+          {
+            "id": "community",
+            "type": "other",
+            "name": "Community",
+            "extraRequired": [],
+            "extraSupported": []
+          }
+        ],
+        "behaviorHints": {
+          "adult": false,
+          "p2p": false,
+          "configurable": false,
+          "configurationRequired": false
+        }
+      },
+      "transportUrl": "https://v3-cinemeta.strem.io/manifest.json",
+      "flags": {
+        "official": true,
+        "protected": true
+      }
+    },
+    {
+      "manifest": {
+        "id": "com.linvo.stremiochannels",
+        "version": "1.30.7",
+        "name": "YouTube",
+        "contactEmail": null,
+        "description": "Watch your favourite YouTube channels ad-free and get notified when they upload new videos.",
+        "logo": null,
+        "background": null,
+        "types": [
+          "channel"
+        ],
+        "resources": [
+          "catalog",
+          "meta"
+        ],
+        "idPrefixes": [
+          "yt_id:"
+        ],
+        "catalogs": [
+          {
+            "id": "top",
+            "type": "channel",
+            "name": null,
+            "extra": [
+              {
+                "name": "search",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              },
+              {
+                "name": "genre",
+                "isRequired": false,
+                "options": [
+                  "Animation",
+                  "Automotive",
+                  "Beauty & Fashion",
+                  "Causes & Non-profits",
+                  "Comedy",
+                  "Cooking & Health",
+                  "Film & Entertainment",
+                  "From TV",
+                  "Gaming",
+                  "Lifestyle",
+                  "Music",
+                  "News & Politics",
+                  "Sports"
+                ],
+                "optionsLimit": 1
+              },
+              {
+                "name": "skip",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              }
+            ]
+          },
+          {
+            "id": "videos",
+            "type": "channel",
+            "name": null,
+            "extra": [
+              {
+                "name": "search",
+                "isRequired": true,
+                "options": [],
+                "optionsLimit": 1
+              }
+            ]
+          }
+        ],
+        "addonCatalogs": [],
+        "behaviorHints": {
+          "adult": false,
+          "p2p": false,
+          "configurable": false,
+          "configurationRequired": false
+        }
+      },
+      "transportUrl": "https://v3-channels.strem.io/manifest.json",
+      "flags": {
+        "official": true,
+        "protected": false
+      }
+    },
+    {
+      "manifest": {
+        "id": "org.stremio.watchhub",
+        "version": "1.15.0",
+        "name": "WatchHub",
+        "contactEmail": null,
+        "description": "Find where to stream your favorite movies and shows amongst Netflix, iTunes, Hulu, Amazon, HBO GO and many others. Supports many countries.",
+        "logo": "https://www.strem.io/images/watchhub-logo.png",
+        "background": null,
+        "types": [
+          "movie",
+          "series"
+        ],
+        "resources": [
+          "stream"
+        ],
+        "idPrefixes": [
+          "tt"
+        ],
+        "catalogs": [],
+        "addonCatalogs": [],
+        "behaviorHints": {
+          "adult": false,
+          "p2p": false,
+          "configurable": false,
+          "configurationRequired": false
+        }
+      },
+      "transportUrl": "https://watchhub.strem.io/manifest.json",
+      "flags": {
+        "official": true,
+        "protected": false
+      }
+    },
+    {
+      "manifest": {
+        "id": "org.stremio.pubdomainmovies",
+        "version": "1.0.0",
+        "name": "Public Domain Movies",
+        "contactEmail": null,
+        "description": "Torrents for public domain movies. Includes a collection of more then 500 public domain movies.",
+        "logo": "https://johnserv531.github.io/gh-images/1586344884.jpg",
+        "background": null,
+        "types": [
+          "movie"
+        ],
+        "resources": [
+          "catalog",
+          "stream"
+        ],
+        "idPrefixes": [
+          "tt"
+        ],
+        "catalogs": [
+          {
+            "id": "publicdomainmovies",
+            "type": "movie",
+            "name": null,
+            "extra": [
+              {
+                "name": "skip",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              },
+              {
+                "name": "search",
+                "isRequired": false,
+                "options": [],
+                "optionsLimit": 1
+              }
+            ]
+          }
+        ],
+        "addonCatalogs": [],
+        "behaviorHints": {
+          "adult": false,
+          "p2p": false,
+          "configurable": false,
+          "configurationRequired": false
+        }
+      },
+      "transportUrl": "https://caching.stremio.net/publicdomainmovies.now.sh/manifest.json",
+      "flags": {
+        "official": true,
+        "protected": false
+      }
+    },
+    {
+      "manifest": {
+        "id": "org.stremio.opensubtitlesv3",
+        "version": "1.0.0",
+        "name": "OpenSubtitles v3",
+        "contactEmail": null,
+        "description": "OpenSubtitles v3 Addon for Stremio",
+        "logo": "http://www.strem.io/images/addons/opensubtitles-logo.png",
+        "background": null,
+        "types": [
+          "movie",
+          "series"
+        ],
+        "resources": [
+          "subtitles"
+        ],
+        "idPrefixes": [
+          "tt"
+        ],
+        "catalogs": [],
+        "addonCatalogs": [],
+        "behaviorHints": {
+          "adult": false,
+          "p2p": false,
+          "configurable": false,
+          "configurationRequired": false
+        }
+      },
+      "transportUrl": "https://opensubtitles-v3.strem.io/manifest.json",
+      "flags": {
+        "official": true,
+        "protected": false
+      }
+    },
+    {
+      "manifest": {
+        "id": "org.stremio.local",
+        "version": "1.10.0",
+        "name": "Local Files (without catalog support)",
+        "contactEmail": null,
+        "description": "Local add-on to find playable files: .torrent, .mp4, .mkv and .avi",
+        "logo": null,
+        "background": null,
+        "types": [
+          "movie",
+          "series",
+          "other"
+        ],
+        "resources": [
+          {
+            "name": "meta",
+            "types": [
+              "other"
+            ],
+            "idPrefixes": [
+              "local:",
+              "bt:"
+            ]
+          },
+          {
+            "name": "stream",
+            "types": [
+              "movie",
+              "series"
+            ],
+            "idPrefixes": [
+              "tt"
+            ]
+          }
+        ],
+        "idPrefixes": null,
+        "catalogs": [],
+        "addonCatalogs": [],
+        "behaviorHints": {
+          "adult": false,
+          "p2p": false,
+          "configurable": false,
+          "configurationRequired": false
+        }
+      },
+      "transportUrl": "http://127.0.0.1:11470/local-addon/manifest.json",
+      "flags": {
+        "official": true,
+        "protected": true
+      }
+    }
+  ],
+  "addonsLocked": false,
+  "settings": {
+    "interfaceLanguage": "eng",
+    "hideSpoilers": false,
+    "gamepadSupport": false,
+    "streamingServerUrl": "http://127.0.0.1:11470/",
+    "playerType": null,
+    "bingeWatching": true,
+    "playInBackground": true,
+    "hardwareDecoding": true,
+    "videoMode": null,
+    "frameRateMatchingStrategy": "FrameRateOnly",
+    "nextVideoNotificationDuration": 35000,
+    "audioPassthrough": false,
+    "audioLanguage": "eng",
+    "secondaryAudioLanguage": null,
+    "subtitlesLanguage": "eng",
+    "secondarySubtitlesLanguage": null,
+    "subtitlesAutoSelect": true,
+    "subtitlesSize": 100,
+    "subtitlesFont": "Roboto",
+    "subtitlesBold": false,
+    "subtitlesOffset": 5,
+    "subtitlesTextColor": "#FFFFFFFF",
+    "subtitlesBackgroundColor": "#00000000",
+    "subtitlesOutlineColor": "#000000",
+    "subtitlesOpacity": 100,
+    "assSubtitlesStyling": false,
+    "escExitFullscreen": true,
+    "seekTimeDuration": 10000,
+    "seekShortTimeDuration": 3000,
+    "pauseOnMinimize": false,
+    "quitOnClose": true,
+    "surroundSound": false,
+    "streamingServerWarningDismissed": null,
+    "serverInForeground": false,
+    "sendCrashReports": true
+  }
+}

--- a/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_search_history_bucket_empty.snap
+++ b/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_search_history_bucket_empty.snap
@@ -1,0 +1,9 @@
+---
+source: src/unit_tests/snapshots.rs
+expression: "SearchHistoryBucket::default()"
+snapshot_kind: text
+---
+{
+  "uid": null,
+  "items": {}
+}

--- a/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_server_urls_bucket_empty.snap
+++ b/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_server_urls_bucket_empty.snap
@@ -1,0 +1,9 @@
+---
+source: src/unit_tests/snapshots.rs
+expression: "ServerUrlsBucket::default()"
+snapshot_kind: text
+---
+{
+  "uid": null,
+  "items": {}
+}

--- a/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_streams_bucket_empty.snap
+++ b/src/unit_tests/snapshots/stremio_core__unit_tests__snapshots__snapshot_streams_bucket_empty.snap
@@ -1,0 +1,9 @@
+---
+source: src/unit_tests/snapshots.rs
+expression: "StreamsBucket::default()"
+snapshot_kind: text
+---
+{
+  "uid": null,
+  "items": []
+}


### PR DESCRIPTION
## Summary

Adds a new `src/unit_tests/snapshots.rs` module that uses the `insta` crate to **freeze the serialized JSON shape** of every bucket that `stremio-core` writes to persistent storage. Each storage key listed in [`src/constants.rs`](src/constants.rs) now has a committed `.snap` fixture; any schema or field-name change to one of these types produces a visible `cargo insta review` diff that cannot accidentally land.

## Why this change

Storage keys (`profile`, `library`, `library_recent`, `streams`, `search_history`, `streaming_server_urls`, `notifications`, `calendar`, `dismissed_events`) are **installed on end-user devices**. A silent rename of a serialized field — say a typo fix on a variant, or a `#[serde(rename)]` added during a refactor — breaks every existing install with no compiler warning and no user-visible cue until someone tries to load their saved state.

The existing coverage in `src/unit_tests/serde/` tests round-trips for individual types, but has no complete tripwire for the composite bucket shapes. If someone adds a field to `Profile` that defaults to `serde_json::Value::Null` on deserialization but changes the serialized output, the round-trip tests still pass. The snapshot suite catches that kind of drift.

## Effect

- **Any field rename, shape change, or default-value change** on a storage-bound type produces an `insta` diff in CI. Contributors can't accidentally break existing user data.
- Updating a snapshot intentionally is still fast: `cargo insta review` → inspect the diff → accept. The expected pairing with a migration step in [`src/runtime/env.rs`](src/runtime/env.rs) is now a visible, enforceable reviewer checkbox rather than an unwritten rule.
- Zero runtime behavior change. Tests-only addition.

## Scope chosen deliberately

**In scope (this PR):** storage bucket types — the persistence contract.
- `Profile` (default state, including the bundled official addons)
- `LibraryBucket` (empty) — covers both `library` and `library_recent`
- `StreamsBucket`, `SearchHistoryBucket`, `ServerUrlsBucket`, `NotificationsBucket`, `DismissedEventsBucket` (empty)

**Out of scope (not this PR):**
- `Msg` / `Action` / `Event` JSON — these are dispatch-internal, not persisted. Breaking them affects live clients (where the on-the-wire contract matters for a running app session), but doesn't corrupt installed user data. The existing `src/unit_tests/serde/` suite covers this class at the type level.
- Deep-link URLs — already covered by existing `src/unit_tests/deep_links/*.rs` tests (now with a round-trip helper for the flate2-encoded player URL, see #974).

## Files changed

- `src/unit_tests/snapshots.rs` — new, 7 tests.
- `src/unit_tests/snapshots/*.snap` — 7 committed fixtures.
- `src/unit_tests/mod.rs` — register the module.
- `Cargo.toml` — add `insta = { version = "1", features = ["json"] }` to `[dev-dependencies]`.

## How to review a snapshot change in a future PR

When a legitimate schema change lands, the author runs:

```
cargo insta review
```

which shows each new/changed snapshot side-by-side with the previous committed version. The author accepts the diff and commits the updated `.snap` file in the same PR as the code change. Reviewers see the `.snap` diff alongside the type change and can verify:

1. Is the rename/addition intentional?
2. Is there a migration step in `src/runtime/env.rs` for it?
3. Does the migration have its own test fixture?

## Test plan

Verified locally (Rust 1.85.1 `stable-x86_64-pc-windows-gnu`):

- [x] `cargo test -p stremio-core --lib` — **209 passed, 0 failed** (202 original + 7 new snapshot tests)
- [x] `cargo clippy --all --no-deps -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Dependency on other PRs

- **Independent** of #967 / #969 / #973 / #974. Merges in any order.
- Lives under `[dev-dependencies]` only, so no effect on published crate graph.