### PR TITLE
Advance video_id to next episode when marking a video as watched

### DIFF
--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -158,6 +158,8 @@ impl<E: Env + 'static> UpdateWithCtx<E> for MetaDetails {
                             .map(|video| video.id.to_owned());
                         if let Some(next_video_id) = next_video_id {
                             library_item.advance_to_video(&next_video_id);
+                        } else {
+                            library_item.state.time_offset = 0;
                         }
                     }
                     Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(library_item)))

--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -155,9 +155,9 @@ impl<E: Env + 'static> UpdateWithCtx<E> for MetaDetails {
                             .iter()
                             .find_map(|item| item.content.as_ref().and_then(|c| c.ready()))
                             .and_then(|meta_item| meta_item.next_video(&video.id))
-                            .map(|v| v.id.to_owned());
+                            .map(|video| video.id.to_owned());
                         if let Some(next_video_id) = next_video_id {
-                            library_item.state.video_id = Some(next_video_id);
+                            library_item.advance_to_video(&next_video_id);
                         }
                     }
                     Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(library_item)))

--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -147,7 +147,19 @@ impl<E: Env + 'static> UpdateWithCtx<E> for MetaDetails {
                 (Some(library_item), Some(watched)) => {
                     let mut library_item = library_item.to_owned();
                     library_item.mark_video_as_watched::<E>(watched, video, *is_watched);
-
+                    if *is_watched
+                        && library_item.state.video_id.as_deref() == Some(video.id.as_str())
+                    {
+                        let next_video_id = self
+                            .meta_items
+                            .iter()
+                            .find_map(|item| item.content.as_ref().and_then(|c| c.ready()))
+                            .and_then(|meta_item| meta_item.next_video(&video.id))
+                            .map(|v| v.id.to_owned());
+                        if let Some(next_video_id) = next_video_id {
+                            library_item.state.video_id = Some(next_video_id);
+                        }
+                    }
                     Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(library_item)))
                         .unchanged()
                 }

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -120,6 +120,9 @@ pub struct Player {
     pub loaded: bool,
     #[serde(skip_serializing)]
     pub ended: bool,
+    /// Whether the selected video has been manually marked as watched
+    #[serde(skip_serializing)]
+    pub marked_video_as_watched: bool,
     #[serde(skip_serializing)]
     pub paused: Option<bool>,
     #[serde(skip_serializing)]
@@ -156,7 +159,11 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                         .as_ref()
                         .map(|meta_request| &meta_request.path.id)
                 {
-                    item_state_update(&mut self.library_item, self.next_video.as_ref())
+                    item_state_update(
+                        &mut self.library_item,
+                        self.next_video.as_ref(),
+                        self.marked_video_as_watched,
+                    )
                 } else {
                     Effects::none().unchanged()
                 };
@@ -293,6 +300,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                 self.loaded = false;
                 self.ended = false;
                 self.paused = None;
+                self.marked_video_as_watched = false;
                 trakt_event_effects
                     .join(item_state_update_effects)
                     .join(selected_effects)
@@ -342,8 +350,11 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     None,
                 );
 
-                let item_state_update_effects =
-                    item_state_update(&mut self.library_item, self.next_video.as_ref());
+                let item_state_update_effects = item_state_update(
+                    &mut self.library_item,
+                    self.next_video.as_ref(),
+                    self.marked_video_as_watched,
+                );
                 let push_to_library_effects = match &self.library_item {
                     Some(library_item) => Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(
                         library_item.to_owned(),
@@ -369,6 +380,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                 self.loaded = false;
                 self.ended = false;
                 self.paused = None;
+                self.marked_video_as_watched = false;
 
                 trakt_event_effects
                     .join(seek_history_effects)
@@ -720,22 +732,18 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
             Msg::Action(Action::Player(ActionPlayer::MarkVideoAsWatched(video, is_watched))) => {
                 match (&self.library_item, &self.watched) {
                     (Some(library_item), Some(watched)) => {
+                        // advancing video_id to the next video is deferred to item_state_update,
+                        // otherwise TimeChanged would reset it back to the playing video
+                        let selected_video_id = self
+                            .selected
+                            .as_ref()
+                            .and_then(|selected| selected.stream_request.as_ref())
+                            .map(|stream_request| &stream_request.path.id);
+                        if selected_video_id == Some(&video.id) {
+                            self.marked_video_as_watched = *is_watched;
+                        }
                         let mut library_item = library_item.to_owned();
                         library_item.mark_video_as_watched::<E>(watched, video, *is_watched);
-                        if *is_watched
-                            && library_item.state.video_id.as_deref() == Some(video.id.as_str())
-                        {
-                            let next_video_id = self
-                                .meta_item
-                                .as_ref()
-                                .and_then(|m| m.content.as_ref())
-                                .and_then(|m| m.ready())
-                                .and_then(|m| m.next_video(&video.id))
-                                .map(|v| v.id.to_owned());
-                            if let Some(next_video_id) = next_video_id {
-                                library_item.state.video_id = Some(next_video_id);
-                            }
-                        }
                         Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(library_item)))
                             .unchanged()
                     }
@@ -975,11 +983,13 @@ fn push_to_library<E: Env + 'static>(
 fn item_state_update(
     library_item: &mut Option<LibraryItem>,
     next_video: Option<&Video>,
+    marked_video_as_watched: bool,
 ) -> Effects {
     match library_item {
         Some(library_item)
-            if library_item.state.time_offset as f64
-                > library_item.state.duration as f64 * CREDITS_THRESHOLD_COEF =>
+            if marked_video_as_watched
+                || library_item.state.time_offset as f64
+                    > library_item.state.duration as f64 * CREDITS_THRESHOLD_COEF =>
         {
             library_item.state.time_offset = 0;
             if let Some(next_video) = next_video {

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -723,7 +723,20 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     (Some(library_item), Some(watched)) => {
                         let mut library_item = library_item.to_owned();
                         library_item.mark_video_as_watched::<E>(watched, video, *is_watched);
-
+                        if *is_watched
+                            && library_item.state.video_id.as_deref() == Some(video.id.as_str())
+                        {
+                            let next_video_id = self
+                                .meta_item
+                                .as_ref()
+                                .and_then(|m| m.content.as_ref())
+                                .and_then(|m| m.ready())
+                                .and_then(|m| m.next_video(&video.id))
+                                .map(|v| v.id.to_owned());
+                            if let Some(next_video_id) = next_video_id {
+                                library_item.state.video_id = Some(next_video_id);
+                            }
+                        }
                         Effects::msg(Msg::Internal(Internal::UpdateLibraryItem(library_item)))
                             .unchanged()
                     }

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -39,7 +39,6 @@ use stremio_watched_bitfield::WatchedBitField;
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use derivative::Derivative;
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use once_cell::sync::Lazy;
@@ -1044,36 +1043,13 @@ fn next_video_update(
                 content: Some(Loadable::Ready(meta_item)),
                 ..
             }),
-        ) => meta_item
-            .videos
-            .iter()
-            .find_position(|video| video.id == *video_id)
-            .and_then(|(position, current_video)| {
-                meta_item
-                    .videos
-                    .get(position + 1)
-                    .map(|next_video| (current_video, next_video))
-            })
-            .filter(|(current_video, next_video)| {
-                let current_season = current_video
-                    .series_info
-                    .as_ref()
-                    .map(|info| info.season)
-                    .unwrap_or_default();
-                let next_season = next_video
-                    .series_info
-                    .as_ref()
-                    .map(|info| info.season)
-                    .unwrap_or_default();
-                next_season != 0 || current_season == next_season
-            })
-            .map(|(_, next_video)| {
-                let mut next_video = next_video.clone();
-                if let Some(stream) = stream {
-                    next_video.streams = vec![stream.clone()];
-                }
-                next_video
-            }),
+        ) => meta_item.next_video(video_id).map(|next_video| {
+            let mut next_video = next_video.clone();
+            if let Some(stream) = stream {
+                next_video.streams = vec![stream.clone()];
+            }
+            next_video
+        }),
         _ => None,
     };
     eq_update(video, next_video)

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -983,14 +983,7 @@ fn item_state_update(
         {
             library_item.state.time_offset = 0;
             if let Some(next_video) = next_video {
-                library_item.state.video_id = Some(next_video.id.to_owned());
-                library_item.state.overall_time_watched = library_item
-                    .state
-                    .overall_time_watched
-                    .saturating_add(library_item.state.time_watched);
-                library_item.state.time_watched = 0;
-                library_item.state.flagged_watched = 0;
-                library_item.state.time_offset = 1;
+                library_item.advance_to_video(&next_video.id);
             };
         }
         _ => {}

--- a/src/types/library/library_item.rs
+++ b/src/types/library/library_item.rs
@@ -132,6 +132,18 @@ impl LibraryItem {
         }
     }
 
+    /// Advances the continue watching pointer to the given video and resets the playback state.
+    pub fn advance_to_video(&mut self, video_id: &str) {
+        self.state.video_id = Some(video_id.to_owned());
+        self.state.overall_time_watched = self
+            .state
+            .overall_time_watched
+            .saturating_add(self.state.time_watched);
+        self.state.time_watched = 0;
+        self.state.flagged_watched = 0;
+        self.state.time_offset = 1;
+    }
+
     pub fn mark_videos_as_watched<E: Env>(
         &mut self,
         watched: &WatchedBitField,

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -275,11 +275,7 @@ impl MetaItem {
         self.videos
             .iter()
             .find_position(|v| v.id == video_id)
-            .and_then(|(pos, current)| {
-                self.videos
-                    .get(pos + 1)
-                    .map(|next| (current, next))
-            })
+            .and_then(|(pos, current)| self.videos.get(pos + 1).map(|next| (current, next)))
             .filter(|(current, next)| {
                 let cur_season = current
                     .series_info

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -268,6 +268,34 @@ impl MetaItem {
         }
     }
 
+    /// Returns the next video after `video_id` in series order, applying the same
+    /// season-boundary filter used by the player's automatic advancement (season 0
+    /// specials are not crossed unless the current video is also in season 0).
+    pub fn next_video(&self, video_id: &str) -> Option<&Video> {
+        self.videos
+            .iter()
+            .find_position(|v| v.id == video_id)
+            .and_then(|(pos, current)| {
+                self.videos
+                    .get(pos + 1)
+                    .map(|next| (current, next))
+            })
+            .filter(|(current, next)| {
+                let cur_season = current
+                    .series_info
+                    .as_ref()
+                    .map(|s| s.season)
+                    .unwrap_or_default();
+                let next_season = next
+                    .series_info
+                    .as_ref()
+                    .map(|s| s.season)
+                    .unwrap_or_default();
+                next_season != 0 || cur_season == next_season
+            })
+            .map(|(_, next)| next)
+    }
+
     /// Returns a vector of videos for a given season
     pub fn videos_by_season(&self, season: u32) -> Vec<&Video> {
         self.videos

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -430,3 +430,57 @@ pub struct MetaItemBehaviorHints {
     #[serde(flatten)]
     pub other: HashMap<String, serde_json::Value>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_video(id: &str, season: u32, episode: u32) -> Video {
+        Video {
+            id: id.to_owned(),
+            series_info: Some(SeriesInfo { season, episode }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn next_video() {
+        let meta_item = MetaItem {
+            preview: Default::default(),
+            videos: vec![
+                create_video("s0e1", 0, 1),
+                create_video("s0e2", 0, 2),
+                create_video("s1e1", 1, 1),
+                create_video("s1e2", 1, 2),
+                create_video("s0e3", 0, 3),
+            ],
+        };
+        assert_eq!(
+            meta_item.next_video("s0e1").map(|video| video.id.as_str()),
+            Some("s0e2")
+        );
+        assert_eq!(
+            meta_item.next_video("s0e2").map(|video| video.id.as_str()),
+            Some("s1e1")
+        );
+        assert_eq!(
+            meta_item.next_video("s1e1").map(|video| video.id.as_str()),
+            Some("s1e2")
+        );
+        assert_eq!(
+            meta_item.next_video("s1e2").map(|video| video.id.as_str()),
+            None,
+            "should not cross into season 0 specials"
+        );
+        assert_eq!(
+            meta_item.next_video("s0e3").map(|video| video.id.as_str()),
+            None
+        );
+        assert_eq!(
+            meta_item
+                .next_video("missing")
+                .map(|video| video.id.as_str()),
+            None
+        );
+    }
+}

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -268,9 +268,7 @@ impl MetaItem {
         }
     }
 
-    /// Returns the next video after `video_id` in series order, applying the same
-    /// season-boundary filter used by the player's automatic advancement (season 0
-    /// specials are not crossed unless the current video is also in season 0).
+    /// Returns the next video after the given one, without crossing into season 0 specials
     pub fn next_video(&self, video_id: &str) -> Option<&Video> {
         self.videos
             .iter()

--- a/src/unit_tests/meta_details/mark_video_as_watched.rs
+++ b/src/unit_tests/meta_details/mark_video_as_watched.rs
@@ -1,0 +1,142 @@
+use crate::{
+    constants::{CINEMETA_URL, META_RESOURCE_NAME, OFFICIAL_ADDONS},
+    models::{
+        ctx::Ctx,
+        meta_details::{MetaDetails, Selected},
+    },
+    runtime::{
+        msg::{Action, ActionLoad, ActionMetaDetails},
+        EnvFutureExt, Runtime, RuntimeAction, TryEnvFuture,
+    },
+    types::{
+        addon::{ResourcePath, ResourceResponse},
+        library::{LibraryBucket, LibraryItem, LibraryItemState},
+        profile::Profile,
+        resource::{MetaItem, MetaItemPreview, SeriesInfo, Video},
+    },
+    unit_tests::{default_fetch_handler, Request, TestEnv, FETCH_HANDLER},
+};
+use chrono::{DateTime, Utc};
+use futures::future;
+use std::any::Any;
+use stremio_derive::Model;
+
+#[derive(Model, Default, Clone, Debug)]
+#[model(TestEnv)]
+struct TestModel {
+    ctx: Ctx,
+    meta_details: MetaDetails,
+}
+
+fn create_video(season: u32, episode: u32) -> Video {
+    Video {
+        id: format!("tt123456:{season}:{episode}"),
+        title: format!("S{season}E{episode}"),
+        series_info: Some(SeriesInfo { season, episode }),
+        ..Default::default()
+    }
+}
+
+fn fetch_handler(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+    match request {
+        Request { url, .. } if url == "https://v3-cinemeta.strem.io/meta/series/tt123456.json" => {
+            future::ok(Box::new(ResourceResponse::Meta {
+                meta: MetaItem {
+                    preview: MetaItemPreview {
+                        id: "tt123456".to_owned(),
+                        r#type: "series".to_owned(),
+                        ..Default::default()
+                    },
+                    videos: vec![create_video(1, 1), create_video(1, 2)],
+                },
+            }) as Box<dyn Any + Send>)
+            .boxed_env()
+        }
+        _ => default_fetch_handler(request),
+    }
+}
+
+#[test]
+fn mark_video_as_watched_advances_video_id() {
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+
+    let library_item = LibraryItem {
+        id: "tt123456".to_owned(),
+        name: "Test Series".to_owned(),
+        r#type: "series".to_owned(),
+        poster: None,
+        poster_shape: Default::default(),
+        removed: false,
+        temp: false,
+        ctime: None,
+        mtime: DateTime::<Utc>::default(),
+        state: LibraryItemState {
+            video_id: Some("tt123456:1:1".to_owned()),
+            ..Default::default()
+        },
+        behavior_hints: Default::default(),
+    };
+    let (runtime, _rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx {
+                profile: Profile {
+                    addons: OFFICIAL_ADDONS
+                        .iter()
+                        .filter(|addon| addon.transport_url == *CINEMETA_URL)
+                        .cloned()
+                        .collect(),
+                    ..Default::default()
+                },
+                library: LibraryBucket {
+                    uid: None,
+                    items: vec![("tt123456".to_owned(), library_item)]
+                        .into_iter()
+                        .collect(),
+                },
+                ..Default::default()
+            },
+            meta_details: Default::default(),
+        },
+        vec![],
+        1000,
+    );
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Load(ActionLoad::MetaDetails(Selected {
+                meta_path: ResourcePath {
+                    resource: META_RESOURCE_NAME.to_owned(),
+                    r#type: "series".to_owned(),
+                    id: "tt123456".to_owned(),
+                    extra: vec![],
+                },
+                stream_path: None,
+                guess_stream: false,
+            })),
+        });
+    });
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::MetaDetails(ActionMetaDetails::MarkVideoAsWatched(
+                create_video(1, 1),
+                true,
+            )),
+        });
+    });
+
+    let model = runtime.model().unwrap();
+    let library_item = model.ctx.library.items.get("tt123456").unwrap();
+    assert_eq!(
+        library_item.state.video_id,
+        Some("tt123456:1:2".to_owned()),
+        "video_id should advance to the next episode after marking current as watched",
+    );
+    assert_eq!(
+        library_item.state.time_offset, 1,
+        "time_offset should be reset when advancing to the next episode",
+    );
+}

--- a/src/unit_tests/meta_details/mark_video_as_watched.rs
+++ b/src/unit_tests/meta_details/mark_video_as_watched.rs
@@ -28,6 +28,9 @@ struct TestModel {
     meta_details: MetaDetails,
 }
 
+const PREVIOUS_TIME_WATCHED: u64 = 40 * 60 * 1000;
+const PREVIOUS_OVERALL_TIME_WATCHED: u64 = 5 * 60 * 1000;
+
 fn create_video(season: u32, episode: u32) -> Video {
     Video {
         id: format!("tt123456:{season}:{episode}"),
@@ -56,12 +59,8 @@ fn fetch_handler(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
     }
 }
 
-#[test]
-fn mark_video_as_watched_advances_video_id() {
-    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
-    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
-
-    let library_item = LibraryItem {
+fn create_library_item(video_id: &str) -> LibraryItem {
+    LibraryItem {
         id: "tt123456".to_owned(),
         name: "Test Series".to_owned(),
         r#type: "series".to_owned(),
@@ -72,11 +71,24 @@ fn mark_video_as_watched_advances_video_id() {
         ctime: None,
         mtime: DateTime::<Utc>::default(),
         state: LibraryItemState {
-            video_id: Some("tt123456:1:1".to_owned()),
+            video_id: Some(video_id.to_owned()),
+            time_offset: PREVIOUS_TIME_WATCHED,
+            time_watched: PREVIOUS_TIME_WATCHED,
+            overall_time_watched: PREVIOUS_OVERALL_TIME_WATCHED,
+            flagged_watched: 1,
+            duration: 60 * 60 * 1000,
             ..Default::default()
         },
         behavior_hints: Default::default(),
-    };
+    }
+}
+
+#[test]
+fn mark_video_as_watched_advances_video_id() {
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+
+    let library_item = create_library_item("tt123456:1:1");
     let (runtime, _rx) = Runtime::<TestEnv, _>::new(
         TestModel {
             ctx: Ctx {
@@ -138,5 +150,88 @@ fn mark_video_as_watched_advances_video_id() {
     assert_eq!(
         library_item.state.time_offset, 1,
         "time_offset should be reset when advancing to the next episode",
+    );
+    assert_eq!(
+        library_item.state.time_watched, 0,
+        "time_watched should not carry over to the next episode",
+    );
+    assert_eq!(
+        library_item.state.flagged_watched, 0,
+        "flagged_watched should be reset for the next episode",
+    );
+    assert_eq!(
+        library_item.state.overall_time_watched,
+        PREVIOUS_OVERALL_TIME_WATCHED + PREVIOUS_TIME_WATCHED,
+        "previous episode time_watched should be folded into overall_time_watched",
+    );
+}
+
+#[test]
+fn mark_last_video_as_watched_clears_continue_watching_progress() {
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+
+    let library_item = create_library_item("tt123456:1:2");
+    let (runtime, _rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx {
+                profile: Profile {
+                    addons: OFFICIAL_ADDONS
+                        .iter()
+                        .filter(|addon| addon.transport_url == *CINEMETA_URL)
+                        .cloned()
+                        .collect(),
+                    ..Default::default()
+                },
+                library: LibraryBucket {
+                    uid: None,
+                    items: vec![("tt123456".to_owned(), library_item)]
+                        .into_iter()
+                        .collect(),
+                },
+                ..Default::default()
+            },
+            meta_details: Default::default(),
+        },
+        vec![],
+        1000,
+    );
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Load(ActionLoad::MetaDetails(Selected {
+                meta_path: ResourcePath {
+                    resource: META_RESOURCE_NAME.to_owned(),
+                    r#type: "series".to_owned(),
+                    id: "tt123456".to_owned(),
+                    extra: vec![],
+                },
+                stream_path: None,
+                guess_stream: false,
+            })),
+        });
+    });
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::MetaDetails(ActionMetaDetails::MarkVideoAsWatched(
+                create_video(1, 2),
+                true,
+            )),
+        });
+    });
+
+    let model = runtime.model().unwrap();
+    let library_item = model.ctx.library.items.get("tt123456").unwrap();
+    assert_eq!(
+        library_item.state.video_id,
+        Some("tt123456:1:2".to_owned()),
+        "video_id should remain on the last episode when there is no next video",
+    );
+    assert_eq!(
+        library_item.state.time_offset, 0,
+        "time_offset should be cleared when there is no next episode",
     );
 }

--- a/src/unit_tests/meta_details/mod.rs
+++ b/src/unit_tests/meta_details/mod.rs
@@ -1,1 +1,2 @@
+mod mark_video_as_watched;
 mod override_selected;

--- a/src/unit_tests/player/mark_video_as_watched.rs
+++ b/src/unit_tests/player/mark_video_as_watched.rs
@@ -148,8 +148,21 @@ fn fetch_handler_s1e2_current(request: Request) -> TryEnvFuture<Box<dyn Any + Se
     }
 }
 
+fn dispatch_time_changed(runtime: &Runtime<TestEnv, TestModel>, time: u64) {
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Player(ActionPlayer::TimeChanged {
+                time,
+                duration: 3_600_000,
+                device: "test_device".to_owned(),
+            }),
+        });
+    });
+}
+
 #[test]
-fn mark_video_as_watched_advances_video_id() {
+fn mark_video_as_watched_advances_video_id_on_unload() {
     let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
     *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler_s1e1_current);
 
@@ -182,12 +195,17 @@ fn mark_video_as_watched_advances_video_id() {
         });
     });
 
+    dispatch_time_changed(&runtime, 600_000);
+
     TestEnv::run(|| {
         runtime.dispatch(RuntimeAction {
             field: None,
             action: Action::Player(ActionPlayer::MarkVideoAsWatched(create_video(1, 1), true)),
         });
     });
+
+    // playback continues after marking and must not lose the advancement
+    dispatch_time_changed(&runtime, 700_000);
 
     assert_eq!(
         runtime
@@ -199,8 +217,27 @@ fn mark_video_as_watched_advances_video_id() {
             .unwrap()
             .state
             .video_id,
+        Some("tt123456:1:1".to_owned()),
+        "video_id should not advance while the video is still playing",
+    );
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Unload,
+        });
+    });
+
+    let model = runtime.model().unwrap();
+    let library_item = model.ctx.library.items.get("tt123456").unwrap();
+    assert_eq!(
+        library_item.state.video_id,
         Some("tt123456:1:2".to_owned()),
-        "video_id should advance to the next episode after marking current as watched",
+        "video_id should advance to the next episode on unload after marking current as watched",
+    );
+    assert_eq!(
+        library_item.state.time_offset, 1,
+        "time_offset should be reset when advancing to the next episode",
     );
 }
 
@@ -238,6 +275,8 @@ fn mark_last_episode_as_watched_does_not_advance() {
         });
     });
 
+    dispatch_time_changed(&runtime, 600_000);
+
     TestEnv::run(|| {
         runtime.dispatch(RuntimeAction {
             field: None,
@@ -245,18 +284,23 @@ fn mark_last_episode_as_watched_does_not_advance() {
         });
     });
 
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Unload,
+        });
+    });
+
+    let model = runtime.model().unwrap();
+    let library_item = model.ctx.library.items.get("tt123456").unwrap();
     assert_eq!(
-        runtime
-            .model()
-            .unwrap()
-            .player
-            .library_item
-            .as_ref()
-            .unwrap()
-            .state
-            .video_id,
+        library_item.state.video_id,
         Some("tt123456:1:2".to_owned()),
         "video_id should remain on the last episode when there is no next video",
+    );
+    assert_eq!(
+        library_item.state.time_offset, 0,
+        "time_offset should be reset when the last episode is marked as watched",
     );
 }
 
@@ -297,7 +341,21 @@ fn mark_video_as_unwatched_does_not_advance_video_id() {
     TestEnv::run(|| {
         runtime.dispatch(RuntimeAction {
             field: None,
+            action: Action::Player(ActionPlayer::MarkVideoAsWatched(create_video(1, 1), true)),
+        });
+    });
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
             action: Action::Player(ActionPlayer::MarkVideoAsWatched(create_video(1, 1), false)),
+        });
+    });
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Unload,
         });
     });
 
@@ -305,13 +363,14 @@ fn mark_video_as_unwatched_does_not_advance_video_id() {
         runtime
             .model()
             .unwrap()
-            .player
-            .library_item
-            .as_ref()
+            .ctx
+            .library
+            .items
+            .get("tt123456")
             .unwrap()
             .state
             .video_id,
         Some("tt123456:1:1".to_owned()),
-        "video_id must not change when marking a video as unwatched",
+        "video_id must not change when the video is marked as unwatched before unload",
     );
 }

--- a/src/unit_tests/player/mark_video_as_watched.rs
+++ b/src/unit_tests/player/mark_video_as_watched.rs
@@ -1,0 +1,317 @@
+use crate::{
+    constants::{META_RESOURCE_NAME, STREAM_RESOURCE_NAME},
+    models::{
+        ctx::Ctx,
+        player::{Player, Selected},
+    },
+    runtime::{
+        msg::{Action, ActionLoad, ActionPlayer},
+        EnvFutureExt, Runtime, RuntimeAction, TryEnvFuture,
+    },
+    types::{
+        addon::{ResourcePath, ResourceRequest, ResourceResponse},
+        library::{LibraryBucket, LibraryItem, LibraryItemState},
+        resource::{MetaItem, MetaItemPreview, SeriesInfo, Stream, StreamSource, Video},
+    },
+    unit_tests::{default_fetch_handler, Request, TestEnv, FETCH_HANDLER},
+};
+use chrono::{DateTime, Utc};
+use futures::future;
+use std::any::Any;
+use stremio_derive::Model;
+
+#[derive(Model, Default, Clone, Debug)]
+#[model(TestEnv)]
+struct TestModel {
+    ctx: Ctx,
+    player: Player,
+}
+
+fn create_video(season: u32, episode: u32) -> Video {
+    Video {
+        id: format!("tt123456:{season}:{episode}"),
+        title: format!("S{season}E{episode}"),
+        released: None,
+        overview: None,
+        thumbnail: None,
+        streams: vec![],
+        series_info: Some(SeriesInfo { season, episode }),
+        trailer_streams: vec![],
+    }
+}
+
+fn create_stream() -> Stream {
+    Stream {
+        source: StreamSource::Url {
+            url: "https://source_url".parse().unwrap(),
+        },
+        name: None,
+        description: None,
+        thumbnail: None,
+        subtitles: vec![],
+        behavior_hints: Default::default(),
+    }
+}
+
+fn make_library_item(video_id: &str) -> LibraryItem {
+    LibraryItem {
+        id: "tt123456".into(),
+        name: "Test Series".into(),
+        r#type: "series".into(),
+        poster: None,
+        poster_shape: Default::default(),
+        removed: false,
+        temp: false,
+        ctime: None,
+        // Use the epoch so that E::now() (frozen by TestEnv::reset) is always >= mtime,
+        // satisfying the merge_items guard (new_item.mtime >= item.mtime).
+        mtime: DateTime::<Utc>::default(),
+        state: LibraryItemState {
+            video_id: Some(video_id.to_owned()),
+            ..Default::default()
+        },
+        behavior_hints: Default::default(),
+    }
+}
+
+fn make_meta_request() -> ResourceRequest {
+    ResourceRequest {
+        base: "https://transport_url/manifest.json".parse().unwrap(),
+        path: ResourcePath {
+            resource: META_RESOURCE_NAME.to_owned(),
+            r#type: "series".to_owned(),
+            id: "tt123456".to_owned(),
+            extra: vec![],
+        },
+    }
+}
+
+fn make_stream_request(video_id: &str) -> ResourceRequest {
+    ResourceRequest {
+        base: "https://transport_url/manifest.json".parse().unwrap(),
+        path: ResourcePath {
+            resource: STREAM_RESOURCE_NAME.to_owned(),
+            r#type: "series".to_owned(),
+            id: video_id.to_owned(),
+            extra: vec![],
+        },
+    }
+}
+
+// Fetch handler for meta [S1E1, S1E2] and the next-stream request for S1E2.
+fn fetch_handler_s1e1_current(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+    match request {
+        Request { url, .. } if url == "https://transport_url/meta/series/tt123456.json" => {
+            future::ok(Box::new(ResourceResponse::Meta {
+                meta: MetaItem {
+                    preview: MetaItemPreview {
+                        id: "tt123456".to_owned(),
+                        r#type: "series".to_owned(),
+                        ..Default::default()
+                    },
+                    // direct construction bypasses the SortedVec adapter, so order matters
+                    videos: vec![create_video(1, 1), create_video(1, 2)],
+                },
+            }) as Box<dyn Any + Send>)
+            .boxed_env()
+        }
+        Request { url, .. }
+            if url == "https://transport_url/stream/series/tt123456%3A1%3A2.json" =>
+        {
+            future::ok(Box::new(ResourceResponse::Streams {
+                streams: vec![],
+            }) as Box<dyn Any + Send>)
+            .boxed_env()
+        }
+        _ => default_fetch_handler(request),
+    }
+}
+
+// Fetch handler for meta [S1E1, S1E2] when loading with S1E2 as current.
+// No next video, so no next-stream fetch arm needed.
+fn fetch_handler_s1e2_current(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+    match request {
+        Request { url, .. } if url == "https://transport_url/meta/series/tt123456.json" => {
+            future::ok(Box::new(ResourceResponse::Meta {
+                meta: MetaItem {
+                    preview: MetaItemPreview {
+                        id: "tt123456".to_owned(),
+                        r#type: "series".to_owned(),
+                        ..Default::default()
+                    },
+                    videos: vec![create_video(1, 1), create_video(1, 2)],
+                },
+            }) as Box<dyn Any + Send>)
+            .boxed_env()
+        }
+        _ => default_fetch_handler(request),
+    }
+}
+
+#[test]
+fn mark_video_as_watched_advances_video_id() {
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler_s1e1_current);
+
+    let (runtime, _rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx {
+                library: LibraryBucket {
+                    uid: None,
+                    items: vec![("tt123456".into(), make_library_item("tt123456:1:1"))]
+                        .into_iter()
+                        .collect(),
+                },
+                ..Default::default()
+            },
+            player: Player::default(),
+        },
+        vec![],
+        1000,
+    );
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Load(ActionLoad::Player(Box::new(Selected {
+                stream: create_stream(),
+                stream_request: Some(make_stream_request("tt123456:1:1")),
+                meta_request: Some(make_meta_request()),
+                subtitles_path: None,
+            }))),
+        });
+    });
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Player(ActionPlayer::MarkVideoAsWatched(create_video(1, 1), true)),
+        });
+    });
+
+    assert_eq!(
+        runtime
+            .model()
+            .unwrap()
+            .player
+            .library_item
+            .as_ref()
+            .unwrap()
+            .state
+            .video_id,
+        Some("tt123456:1:2".to_owned()),
+        "video_id should advance to the next episode after marking current as watched",
+    );
+}
+
+#[test]
+fn mark_last_episode_as_watched_does_not_advance() {
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler_s1e2_current);
+
+    let (runtime, _rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx {
+                library: LibraryBucket {
+                    uid: None,
+                    items: vec![("tt123456".into(), make_library_item("tt123456:1:2"))]
+                        .into_iter()
+                        .collect(),
+                },
+                ..Default::default()
+            },
+            player: Player::default(),
+        },
+        vec![],
+        1000,
+    );
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Load(ActionLoad::Player(Box::new(Selected {
+                stream: create_stream(),
+                stream_request: Some(make_stream_request("tt123456:1:2")),
+                meta_request: Some(make_meta_request()),
+                subtitles_path: None,
+            }))),
+        });
+    });
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Player(ActionPlayer::MarkVideoAsWatched(create_video(1, 2), true)),
+        });
+    });
+
+    assert_eq!(
+        runtime
+            .model()
+            .unwrap()
+            .player
+            .library_item
+            .as_ref()
+            .unwrap()
+            .state
+            .video_id,
+        Some("tt123456:1:2".to_owned()),
+        "video_id should remain on the last episode when there is no next video",
+    );
+}
+
+#[test]
+fn mark_video_as_unwatched_does_not_advance_video_id() {
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler_s1e1_current);
+
+    let (runtime, _rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx {
+                library: LibraryBucket {
+                    uid: None,
+                    items: vec![("tt123456".into(), make_library_item("tt123456:1:1"))]
+                        .into_iter()
+                        .collect(),
+                },
+                ..Default::default()
+            },
+            player: Player::default(),
+        },
+        vec![],
+        1000,
+    );
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Load(ActionLoad::Player(Box::new(Selected {
+                stream: create_stream(),
+                stream_request: Some(make_stream_request("tt123456:1:1")),
+                meta_request: Some(make_meta_request()),
+                subtitles_path: None,
+            }))),
+        });
+    });
+
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Player(ActionPlayer::MarkVideoAsWatched(create_video(1, 1), false)),
+        });
+    });
+
+    assert_eq!(
+        runtime
+            .model()
+            .unwrap()
+            .player
+            .library_item
+            .as_ref()
+            .unwrap()
+            .state
+            .video_id,
+        Some("tt123456:1:1".to_owned()),
+        "video_id must not change when marking a video as unwatched",
+    );
+}

--- a/src/unit_tests/player/mark_video_as_watched.rs
+++ b/src/unit_tests/player/mark_video_as_watched.rs
@@ -118,9 +118,9 @@ fn fetch_handler_s1e1_current(request: Request) -> TryEnvFuture<Box<dyn Any + Se
         Request { url, .. }
             if url == "https://transport_url/stream/series/tt123456%3A1%3A2.json" =>
         {
-            future::ok(Box::new(ResourceResponse::Streams {
-                streams: vec![],
-            }) as Box<dyn Any + Send>)
+            future::ok(
+                Box::new(ResourceResponse::Streams { streams: vec![] }) as Box<dyn Any + Send>
+            )
             .boxed_env()
         }
         _ => default_fetch_handler(request),

--- a/src/unit_tests/player/mod.rs
+++ b/src/unit_tests/player/mod.rs
@@ -1,1 +1,2 @@
+mod mark_video_as_watched;
 mod next_stream;


### PR DESCRIPTION
When a video is marked as watched via `MarkVideoAsWatched`, `video_id` was never updated, so Continue Watching wouldn't advance to the next one. This only worked correctly through the automatic playback path (`item_state_update` at the credits threshold).

**Fix:** Added `MetaItem::next_video()` and advance `video_id` from both `MarkVideoAsWatched` handlers when `is_watched` is true and the marked video matches the current `video_id`. The meta_details handler advances immediately; the player handler defers the advancement to `item_state_update` (Unload / Load with a different meta item) via a new `marked_video_as_watched` flag, because the next `TimeChanged` tick treats `state.video_id != <playing video>` as a video switch and would silently revert an immediate advancement while playback continues.

A couple of things worth noting:

- advancing now goes through a new `LibraryItem::advance_to_video()`, which applies the same state reset as the credits-threshold path (`time_watched` folded into `overall_time_watched`, `flagged_watched` cleared, `time_offset` set to 1), keeping the old state would show the previous episode's progress bar on the next episode's Continue Watching card and resume it from the wrong offset
- marking the last episode as watched in the player sets `time_offset` to 0 on unload, dropping the item from Continue Watching, same as finishing it through the credits
- `next_video()` applies the same season-0 boundary filter as `next_video_update()` in player.rs, which now reuses it instead of duplicating the logic
- the flag is cleared by an opposite `is_watched: false` mark and on Load/Unload

Three integration tests in `src/unit_tests/player/mark_video_as_watched.rs` covering advancement on unload (including a `TimeChanged` after marking, as a regression test for the revert), last episode, and `is_watched: false`. Also added a meta_details test in `src/unit_tests/meta_details/mark_video_as_watched.rs` and a unit test for the `next_video()` season boundary.

Closes #983, closes #876
