### PR TITLE
fix(stremio-watched-bitfield): store bit length in BitField8::new

### DIFF
--- a/stremio-watched-bitfield/src/bitfield8.rs
+++ b/stremio-watched-bitfield/src/bitfield8.rs
@@ -15,9 +15,6 @@ pub struct BitField8 {
 
 impl BitField8 {
     pub fn new(length: usize) -> BitField8 {
-        // `length` is the number of bits (videos); the backing buffer needs
-        // `ceil(length / 8)` bytes. Keep `length` in bits to stay consistent
-        // with `new_with_values`, `set` and `last_index_of`.
         let bytes = (length as f64 / 8.0).ceil() as usize;
         BitField8 {
             length,
@@ -199,17 +196,11 @@ mod tests {
 
     #[test]
     fn new_uses_bit_length() {
-        // `new(n)` must store the number of *bits* (videos) in `length`, the
-        // same convention used by `new_with_values` and `set`. Storing the byte
-        // count instead makes `last_index_of` (which iterates over `0..length`)
-        // under-scan the bitfield.
         let bf = BitField8::new(20);
         assert_eq!(bf.length, 20);
 
         let mut bf = BitField8::new(20);
         bf.set(15, true);
-        // The last set bit is at index 15, well past the first ceil(20/8) = 3
-        // positions that the buggy length would limit the scan to.
         assert_eq!(bf.last_index_of(true), Some(15));
     }
 }

--- a/stremio-watched-bitfield/src/bitfield8.rs
+++ b/stremio-watched-bitfield/src/bitfield8.rs
@@ -15,10 +15,13 @@ pub struct BitField8 {
 
 impl BitField8 {
     pub fn new(length: usize) -> BitField8 {
-        let length = (length as f64 / 8.0).ceil() as usize;
+        // `length` is the number of bits (videos); the backing buffer needs
+        // `ceil(length / 8)` bytes. Keep `length` in bits to stay consistent
+        // with `new_with_values`, `set` and `last_index_of`.
+        let bytes = (length as f64 / 8.0).ceil() as usize;
         BitField8 {
             length,
-            values: vec![0; length],
+            values: vec![0; bytes],
         }
     }
 
@@ -192,5 +195,21 @@ mod tests {
         // If the value is not provided the length is rounded towards the next byte
         let bf = BitField8::try_from((watched, None)).unwrap();
         assert_eq!(bf.length, 16);
+    }
+
+    #[test]
+    fn new_uses_bit_length() {
+        // `new(n)` must store the number of *bits* (videos) in `length`, the
+        // same convention used by `new_with_values` and `set`. Storing the byte
+        // count instead makes `last_index_of` (which iterates over `0..length`)
+        // under-scan the bitfield.
+        let bf = BitField8::new(20);
+        assert_eq!(bf.length, 20);
+
+        let mut bf = BitField8::new(20);
+        bf.set(15, true);
+        // The last set bit is at index 15, well past the first ceil(20/8) = 3
+        // positions that the buggy length would limit the scan to.
+        assert_eq!(bf.last_index_of(true), Some(15));
     }
 }

--- a/stremio-watched-bitfield/src/watched_bitfield.rs
+++ b/stremio-watched-bitfield/src/watched_bitfield.rs
@@ -364,4 +364,25 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn watched_field_anchor_points_to_last_watched_video() {
+        // Mirrors the player flow for a series with no prior watched state:
+        // an empty bitfield is built, then a single watched video is set.
+        // The serialized `WatchedField` anchor must point to the actually
+        // watched video, not collapse to video index 0.
+        let video_ids: Vec<String> = (1..=20).map(|i| format!("tt0:1:{}", i)).collect();
+        let mut watched = WatchedBitField::construct_from_array(vec![], video_ids);
+        // mark the 16th video (index 15) as watched
+        watched.set_video("tt0:1:16", true);
+
+        let field: WatchedField = watched.into();
+        // Serialized as `{anchor_video}:{anchor_length}:{bitfield}`.
+        let serialized = field.to_string();
+        assert!(
+            serialized.starts_with("tt0:1:16:16:"),
+            "anchor should point to the last watched video, got: {}",
+            serialized
+        );
+    }
 }

--- a/stremio-watched-bitfield/src/watched_bitfield.rs
+++ b/stremio-watched-bitfield/src/watched_bitfield.rs
@@ -367,17 +367,11 @@ mod tests {
 
     #[test]
     fn watched_field_anchor_points_to_last_watched_video() {
-        // Mirrors the player flow for a series with no prior watched state:
-        // an empty bitfield is built, then a single watched video is set.
-        // The serialized `WatchedField` anchor must point to the actually
-        // watched video, not collapse to video index 0.
         let video_ids: Vec<String> = (1..=20).map(|i| format!("tt0:1:{}", i)).collect();
         let mut watched = WatchedBitField::construct_from_array(vec![], video_ids);
-        // mark the 16th video (index 15) as watched
         watched.set_video("tt0:1:16", true);
 
         let field: WatchedField = watched.into();
-        // Serialized as `{anchor_video}:{anchor_length}:{bitfield}`.
         let serialized = field.to_string();
         assert!(
             serialized.starts_with("tt0:1:16:16:"),


### PR DESCRIPTION
## Summary

`BitField8::new` stored the byte count (`ceil(length / 8)`) in the `length` field, while `new_with_values`, `set` and `last_index_of` all treat `length` as the number of bits. Because of this, `last_index_of` only scanned the first `ceil(n / 8)` bit positions of any bitfield created through `new`.

The visible effect is a wrong `WatchedField` anchor. The anchor (`anchor_video` / `anchor_length`, documented as the last watched video) is derived from `last_index_of(true)`. A `WatchedBitField` built via `new` (the `construct_from_array` fallback for library items with no prior watched state, and the resize buffer in `construct_with_videos`) serialized an anchor that collapsed to video index 0 with length 1 once the last watched video was past the first `ceil(n / 8)` bits. In the player this happens when watching an episode to the completion threshold on a series with no prior watched state. For a 20 episode series, marking episode 16 watched produced `..:1:1` instead of `..:16:16`. As the serialized `WatchedField` is synced through the API and shared with other Stremio clients, the wrong anchor can misalign or drop watched state when the video list changes.

This is separate from the `last_index_of` off by one fixed in #781, which corrected the scan range but not the `length` value passed into it.

## Fix

Keep `length` in bits and size the backing `Vec<u8>` to `ceil(length / 8)` bytes.

## Tests

- `bitfield8::tests::new_uses_bit_length`: `BitField8::new(n).length == n` and `last_index_of` finds a bit past the first byte.
- `watched_bitfield::tests::watched_field_anchor_points_to_last_watched_video`: the `construct_from_array` + `set_video` flow (as used by the player) produces an anchor pointing at the actually watched video.

Verified locally: `stremio-watched-bitfield` (9 passed) and `stremio-core` (202 passed, single threaded) test suites are green, along with rustfmt and clippy.

Closes #987
