### PR TITLE
Player: fix next episode intermittently falling back to the stream picker

### DIFF
--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -831,6 +831,9 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     _ => Effects::none().unchanged(),
                 };
 
+                let next_stream_effects =
+                    next_stream_update(&mut self.next_stream, &self.next_streams, &self.selected);
+
                 let next_video_effects = next_video_update(
                     &mut self.next_video,
                     &self.next_stream,
@@ -843,9 +846,6 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     &self.next_video,
                     &self.selected,
                 ));
-
-                let next_stream_effects =
-                    next_stream_update(&mut self.next_stream, &self.next_streams, &self.selected);
 
                 let series_info_effects =
                     series_info_update(&mut self.series_info, &self.selected, &self.meta_item);

--- a/src/unit_tests/player/next_stream.rs
+++ b/src/unit_tests/player/next_stream.rs
@@ -173,6 +173,19 @@ fn next_stream() {
         "next stream has same binge group"
     );
 
+    assert_eq!(
+        runtime
+            .model()
+            .unwrap()
+            .player
+            .next_video
+            .as_ref()
+            .unwrap()
+            .streams,
+        vec![create_stream("binge_group")],
+        "next video has the matched next stream embedded"
+    );
+
     TestEnv::run(|| {
         runtime.dispatch(RuntimeAction {
             field: None,


### PR DESCRIPTION
## Problem
Clicking "next episode" sometimes plays the next episode directly, but sometimes drops you back to the stream picker and asks you to choose a stream again even when the current stream already covers every episode.

The cause is an update-ordering race in the player model. In the `ResourceRequestResult` handler, `next_video_update` runs **before** `next_stream_update`. So when the next episode's streams finish loading, `next_video.streams` is computed against a stale `next_stream` (`None`) and is left empty. `next_stream_update` then matches the stream, but `next_video` was already built and `next_video_update` does not run again on playback progress, only on a load or another resource result.

That makes the outcome depend on which resource resolves last:
- another resource (e.g. subtitles) resolves **after** the streams → `next_video_update` re-runs → `deepLinks.player` is populated → next episode works.
- the streams resolve **last** → `next_video_update` never re-runs → `deepLinks.player` stays `null` → fallback to the stream picker.

Hence the intermittent behavior.

## Summary
- reorder `next_stream_update` to run **before** `next_video_update` in the `ResourceRequestResult` handler
- the matched next stream is now applied to `next_video.streams` in the same update tick, regardless of resource load order
- `deepLinks.player` is populated deterministically, so "next episode" stops falling back to the stream picker

## Verification
- binge-watched a series: "next episode" now consistently auto-plays instead of intermittently opening the picker