### PR TITLE
feat: add EPG provider manifest hint

### DIFF
--- a/src/types/addon/manifest.rs
+++ b/src/types/addon/manifest.rs
@@ -450,4 +450,6 @@ pub struct ManifestBehaviorHints {
     pub configurable: bool,
     #[serde(default)]
     pub configuration_required: bool,
+    #[serde(default)]
+    pub epg_provider: bool,
 }

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -370,7 +370,7 @@ pub struct Video {
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub links: Vec<Link>,
-    
+
     // Optional fallback for future addon fields
     #[serde(default, flatten)]
     pub other: HashMap<String, serde_json::Value>,

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -348,31 +348,30 @@ pub struct Video {
     #[serde(default)]
     pub trailer_streams: Vec<Stream>,
     // EPG / rich video metadata
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub start_time: Option<DateTime<Utc>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub end_time: Option<DateTime<Utc>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde_as(deserialize_as = "Option<NumberAsString>")]
     pub runtime: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde_as(deserialize_as = "Option<NumberAsString>")]
     pub release_info: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub genres: Vec<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub cast: Vec<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub director: Vec<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub links: Vec<Link>,
 
-    // Optional fallback for future addon fields
-    #[serde(default, flatten)]
+    #[serde(default, flatten, skip_serializing_if = "HashMap::is_empty")]
     pub other: HashMap<String, serde_json::Value>,
 }
 

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -347,6 +347,33 @@ pub struct Video {
     pub series_info: Option<SeriesInfo>,
     #[serde(default)]
     pub trailer_streams: Vec<Stream>,
+    // EPG / rich video metadata
+    #[serde(default)]
+    pub start_time: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub end_time: Option<DateTime<Utc>>,
+    #[serde(default)]
+    #[serde_as(deserialize_as = "Option<NumberAsString>")]
+    pub runtime: Option<String>,
+    #[serde(default)]
+    #[serde_as(deserialize_as = "Option<NumberAsString>")]
+    pub release_info: Option<String>,
+    #[serde(default)]
+    #[serde_as(deserialize_as = "DefaultOnNull")]
+    pub genres: Vec<String>,
+    #[serde(default)]
+    #[serde_as(deserialize_as = "DefaultOnNull")]
+    pub cast: Vec<String>,
+    #[serde(default)]
+    #[serde_as(deserialize_as = "DefaultOnNull")]
+    pub director: Vec<String>,
+    #[serde(default)]
+    #[serde_as(deserialize_as = "DefaultOnNull")]
+    pub links: Vec<Link>,
+    
+    // Optional fallback for future addon fields
+    #[serde(default, flatten)]
+    pub other: HashMap<String, serde_json::Value>,
 }
 
 impl Video {

--- a/src/unit_tests/ctx/install_addon.rs
+++ b/src/unit_tests/ctx/install_addon.rs
@@ -106,7 +106,7 @@ fn actionctx_installaddon_install_with_user() {
                 url, method, body, ..
             } if url == "https://api.strem.io/api/addonCollectionSet"
                 && method == "POST"
-                && body == "{\"type\":\"AddonCollectionSet\",\"authKey\":\"auth_key\",\"addons\":[{\"manifest\":{\"id\":\"id\",\"version\":\"0.0.1\",\"name\":\"name\",\"contactEmail\":null,\"description\":null,\"logo\":null,\"background\":null,\"types\":[],\"resources\":[],\"idPrefixes\":null,\"catalogs\":[],\"addonCatalogs\":[],\"behaviorHints\":{\"adult\":false,\"p2p\":false,\"configurable\":false,\"configurationRequired\":false}},\"transportUrl\":\"https://transport_url/\",\"flags\":{\"official\":false,\"protected\":false}}]}" =>
+                && body == "{\"type\":\"AddonCollectionSet\",\"authKey\":\"auth_key\",\"addons\":[{\"manifest\":{\"id\":\"id\",\"version\":\"0.0.1\",\"name\":\"name\",\"contactEmail\":null,\"description\":null,\"logo\":null,\"background\":null,\"types\":[],\"resources\":[],\"idPrefixes\":null,\"catalogs\":[],\"addonCatalogs\":[],\"behaviorHints\":{\"adult\":false,\"p2p\":false,\"configurable\":false,\"configurationRequired\":false,\"epgProvider\":false}},\"transportUrl\":\"https://transport_url/\",\"flags\":{\"official\":false,\"protected\":false}}]}" =>
             {
                 future::ok(Box::new(APIResult::Ok( SuccessResponse { success: True {} },
                 )) as Box<dyn Any + Send>).boxed_env()
@@ -205,7 +205,7 @@ fn actionctx_installaddon_install_with_user() {
         Request {
             url: "https://api.strem.io/api/addonCollectionSet".to_owned(),
             method: "POST".to_owned(),
-            body: "{\"type\":\"AddonCollectionSet\",\"authKey\":\"auth_key\",\"addons\":[{\"manifest\":{\"id\":\"id\",\"version\":\"0.0.1\",\"name\":\"name\",\"contactEmail\":null,\"description\":null,\"logo\":null,\"background\":null,\"types\":[],\"resources\":[],\"idPrefixes\":null,\"catalogs\":[],\"addonCatalogs\":[],\"behaviorHints\":{\"adult\":false,\"p2p\":false,\"configurable\":false,\"configurationRequired\":false}},\"transportUrl\":\"https://transport_url/\",\"flags\":{\"official\":false,\"protected\":false}}]}"
+            body: "{\"type\":\"AddonCollectionSet\",\"authKey\":\"auth_key\",\"addons\":[{\"manifest\":{\"id\":\"id\",\"version\":\"0.0.1\",\"name\":\"name\",\"contactEmail\":null,\"description\":null,\"logo\":null,\"background\":null,\"types\":[],\"resources\":[],\"idPrefixes\":null,\"catalogs\":[],\"addonCatalogs\":[],\"behaviorHints\":{\"adult\":false,\"p2p\":false,\"configurable\":false,\"configurationRequired\":false,\"epgProvider\":false}},\"transportUrl\":\"https://transport_url/\",\"flags\":{\"official\":false,\"protected\":false}}]}"
                 .to_owned(),
             ..Default::default()
         },

--- a/src/unit_tests/ctx/notifications/update_notifications.rs
+++ b/src/unit_tests/ctx/notifications/update_notifications.rs
@@ -126,6 +126,7 @@ fn test_pull_notifications_and_play_in_player() {
                     episode: 4,
                 }),
                 trailer_streams: vec![],
+                ..Default::default()
             },
             Video {
                 id: "tt1:1:5".to_owned(),
@@ -139,6 +140,7 @@ fn test_pull_notifications_and_play_in_player() {
                     episode: 5,
                 }),
                 trailer_streams: vec![],
+                ..Default::default()
             },
             Video {
                 id: "tt1:1:6".to_owned(),
@@ -152,6 +154,7 @@ fn test_pull_notifications_and_play_in_player() {
                     episode: 6,
                 }),
                 trailer_streams: vec![],
+                ..Default::default()
             },
             Video {
                 id: "tt1:1:7".to_owned(),

--- a/src/unit_tests/ctx/notifications/update_notifications.rs
+++ b/src/unit_tests/ctx/notifications/update_notifications.rs
@@ -165,6 +165,7 @@ fn test_pull_notifications_and_play_in_player() {
                     episode: 7,
                 }),
                 trailer_streams: vec![],
+                ..Default::default()
             },
         ],
     });

--- a/src/unit_tests/ctx/push_addons_to_api.rs
+++ b/src/unit_tests/ctx/push_addons_to_api.rs
@@ -87,7 +87,7 @@ fn actionctx_pushaddonstoapi_with_user() {
                 url, method, body, ..
             } if url == "https://api.strem.io/api/addonCollectionSet"
                 && method == "POST"
-                && body == "{\"type\":\"AddonCollectionSet\",\"authKey\":\"auth_key\",\"addons\":[{\"manifest\":{\"id\":\"id\",\"version\":\"0.0.1\",\"name\":\"name\",\"contactEmail\":null,\"description\":null,\"logo\":null,\"background\":null,\"types\":[],\"resources\":[],\"idPrefixes\":null,\"catalogs\":[],\"addonCatalogs\":[],\"behaviorHints\":{\"adult\":false,\"p2p\":false,\"configurable\":false,\"configurationRequired\":false}},\"transportUrl\":\"https://transport_url/\",\"flags\":{\"official\":false,\"protected\":false}}]}" =>
+                && body == "{\"type\":\"AddonCollectionSet\",\"authKey\":\"auth_key\",\"addons\":[{\"manifest\":{\"id\":\"id\",\"version\":\"0.0.1\",\"name\":\"name\",\"contactEmail\":null,\"description\":null,\"logo\":null,\"background\":null,\"types\":[],\"resources\":[],\"idPrefixes\":null,\"catalogs\":[],\"addonCatalogs\":[],\"behaviorHints\":{\"adult\":false,\"p2p\":false,\"configurable\":false,\"configurationRequired\":false,\"epgProvider\":false}},\"transportUrl\":\"https://transport_url/\",\"flags\":{\"official\":false,\"protected\":false}}]}" =>
             {
                 future::ok(Box::new(APIResult::Ok(
                     SuccessResponse { success: True {} },
@@ -171,7 +171,7 @@ fn actionctx_pushaddonstoapi_with_user() {
         Request {
             url: "https://api.strem.io/api/addonCollectionSet".to_owned(),
             method: "POST".to_owned(),
-            body: "{\"type\":\"AddonCollectionSet\",\"authKey\":\"auth_key\",\"addons\":[{\"manifest\":{\"id\":\"id\",\"version\":\"0.0.1\",\"name\":\"name\",\"contactEmail\":null,\"description\":null,\"logo\":null,\"background\":null,\"types\":[],\"resources\":[],\"idPrefixes\":null,\"catalogs\":[],\"addonCatalogs\":[],\"behaviorHints\":{\"adult\":false,\"p2p\":false,\"configurable\":false,\"configurationRequired\":false}},\"transportUrl\":\"https://transport_url/\",\"flags\":{\"official\":false,\"protected\":false}}]}"
+            body: "{\"type\":\"AddonCollectionSet\",\"authKey\":\"auth_key\",\"addons\":[{\"manifest\":{\"id\":\"id\",\"version\":\"0.0.1\",\"name\":\"name\",\"contactEmail\":null,\"description\":null,\"logo\":null,\"background\":null,\"types\":[],\"resources\":[],\"idPrefixes\":null,\"catalogs\":[],\"addonCatalogs\":[],\"behaviorHints\":{\"adult\":false,\"p2p\":false,\"configurable\":false,\"configurationRequired\":false,\"epgProvider\":false}},\"transportUrl\":\"https://transport_url/\",\"flags\":{\"official\":false,\"protected\":false}}]}"
                 .to_owned(),
             ..Default::default()
         },

--- a/src/unit_tests/deep_links/video_deep_links.rs
+++ b/src/unit_tests/deep_links/video_deep_links.rs
@@ -21,6 +21,7 @@ fn video_deep_links() {
         streams: vec![],
         series_info: None,
         trailer_streams: vec![],
+        ..Default::default()
     };
     let request = ResourceRequest {
         base: Url::from_str("http://domain.root").unwrap(),

--- a/src/unit_tests/player/mark_video_as_watched.rs
+++ b/src/unit_tests/player/mark_video_as_watched.rs
@@ -37,6 +37,7 @@ fn create_video(season: u32, episode: u32) -> Video {
         streams: vec![],
         series_info: Some(SeriesInfo { season, episode }),
         trailer_streams: vec![],
+        ..Default::default()
     }
 }
 

--- a/src/unit_tests/player/next_stream.rs
+++ b/src/unit_tests/player/next_stream.rs
@@ -47,6 +47,7 @@ fn create_video(season: u32, episode: u32) -> Video {
         streams: vec![],
         series_info: Some(SeriesInfo { season, episode }),
         trailer_streams: vec![],
+        ..Default::default()
     }
 }
 

--- a/src/unit_tests/serde/default_tokens_ext.rs
+++ b/src/unit_tests/serde/default_tokens_ext.rs
@@ -184,7 +184,7 @@ impl DefaultTokens for ManifestBehaviorHints {
         vec![
             Token::Struct {
                 name: "ManifestBehaviorHints",
-                len: 4,
+                len: 5,
             },
             Token::Str("adult"),
             Token::Bool(false),
@@ -193,6 +193,8 @@ impl DefaultTokens for ManifestBehaviorHints {
             Token::Str("configurable"),
             Token::Bool(false),
             Token::Str("configurationRequired"),
+            Token::Bool(false),
+            Token::Str("epgProvider"),
             Token::Bool(false),
             Token::StructEnd,
         ]

--- a/src/unit_tests/serde/manifest_behavior_hints.rs
+++ b/src/unit_tests/serde/manifest_behavior_hints.rs
@@ -9,11 +9,12 @@ fn manifest_behavior_hints() {
             p2p: true,
             configurable: true,
             configuration_required: true,
+            epg_provider: true,
         },
         &[
             Token::Struct {
                 name: "ManifestBehaviorHints",
-                len: 4,
+                len: 5,
             },
             Token::Str("adult"),
             Token::Bool(true),
@@ -22,6 +23,8 @@ fn manifest_behavior_hints() {
             Token::Str("configurable"),
             Token::Bool(true),
             Token::Str("configurationRequired"),
+            Token::Bool(true),
+            Token::Str("epgProvider"),
             Token::Bool(true),
             Token::StructEnd,
         ],
@@ -32,6 +35,7 @@ fn manifest_behavior_hints() {
             p2p: false,
             configurable: false,
             configuration_required: false,
+            epg_provider: false,
         },
         &[
             Token::Struct {

--- a/src/unit_tests/serde/video.rs
+++ b/src/unit_tests/serde/video.rs
@@ -19,6 +19,7 @@ fn video() {
                 streams: vec![],
                 series_info: Some(SeriesInfo::default()),
                 trailer_streams: vec![],
+                ..Default::default()
             },
             Video {
                 id: "id".into(),
@@ -29,6 +30,7 @@ fn video() {
                 streams: vec![],
                 series_info: None,
                 trailer_streams: vec![],
+                ..Default::default()
             },
         ]
         .readable(),
@@ -93,6 +95,7 @@ fn video() {
                 streams: vec![],
                 series_info: None,
                 trailer_streams: vec![],
+                ..Default::default()
             },
             Video {
                 id: "id".into(),
@@ -110,6 +113,7 @@ fn video() {
                 }],
                 series_info: None,
                 trailer_streams: vec![],
+                ..Default::default()
             },
             Video {
                 id: "id".into(),
@@ -127,6 +131,7 @@ fn video() {
                 }],
                 series_info: None,
                 trailer_streams: vec![],
+                ..Default::default()
             },
         ]
         .readable(),
@@ -235,6 +240,7 @@ fn videos_minimal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "1".to_owned(),
@@ -245,6 +251,7 @@ fn videos_minimal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "3".to_owned(),
@@ -255,6 +262,7 @@ fn videos_minimal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
             ],
         }
@@ -310,6 +318,7 @@ fn videos_released_equal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "1".to_owned(),
@@ -320,6 +329,7 @@ fn videos_released_equal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "3".to_owned(),
@@ -330,6 +340,7 @@ fn videos_released_equal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
             ],
         }
@@ -395,6 +406,7 @@ fn videos_released_sequal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "2".to_owned(),
@@ -405,6 +417,7 @@ fn videos_released_sequal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "1".to_owned(),
@@ -415,6 +428,7 @@ fn videos_released_sequal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "nd1".to_owned(),
@@ -425,6 +439,7 @@ fn videos_released_sequal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "nd2".to_owned(),
@@ -435,6 +450,7 @@ fn videos_released_sequal() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
             ],
         }
@@ -512,6 +528,7 @@ fn various_videos_deserialization() {
                         episode: 1,
                     }),
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "S01E02".to_owned(),
@@ -525,6 +542,7 @@ fn various_videos_deserialization() {
                         episode: 2,
                     }),
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "S02E01".to_owned(),
@@ -538,6 +556,7 @@ fn various_videos_deserialization() {
                         episode: 1,
                     }),
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "special1".to_owned(),
@@ -551,6 +570,7 @@ fn various_videos_deserialization() {
                         episode: 1,
                     }),
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "special2".to_owned(),
@@ -564,6 +584,7 @@ fn various_videos_deserialization() {
                         episode: 2,
                     }),
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "M1".to_owned(),
@@ -574,6 +595,7 @@ fn various_videos_deserialization() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "M2".to_owned(),
@@ -584,6 +606,7 @@ fn various_videos_deserialization() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "nd1".to_owned(),
@@ -594,6 +617,7 @@ fn various_videos_deserialization() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
                 Video {
                     id: "nd2".to_owned(),
@@ -604,6 +628,7 @@ fn various_videos_deserialization() {
                     streams: vec![],
                     series_info: None,
                     trailer_streams: vec![],
+                    ..Default::default()
                 },
             ],
         }


### PR DESCRIPTION
## Summary

Adds support for `manifest.behaviorHints.epgProvider` in `stremio-core`.

This matches the EPG implementation introduced in Stremio/stremio-web#1218, where Live TV addons can opt into the native EPG layout by setting:

```json
{
  "behaviorHints": {
    "epgProvider": true
  }
}
```
## Changes

- Added `epgProvider` to `ManifestBehaviorHints`.
- Kept the field defaulting to `false` for backwards compatibility.
- Updated serde expectations and addon API payload tests.

## Testing

- `cargo fmt --check` passed.
- `cargo test` could not be completed locally because the Windows MSVC linker (link.exe) is missing from the environment.