### PR TITLE
Add saved account auth support

### DIFF
--- a/src/models/ctx/update_profile.rs
+++ b/src/models/ctx/update_profile.rs
@@ -22,7 +22,13 @@ pub fn update_profile<E: Env + 'static>(
 ) -> Effects {
     match msg {
         Msg::Internal(Internal::Logout(_)) => {
-            let next_profile = Profile::default();
+            let mut next_profile = Profile {
+                saved_auths: profile.saved_auths.to_owned(),
+                ..Default::default()
+            };
+            if let Some(user_id) = profile.uid() {
+                next_profile.remove_saved_auth(&user_id);
+            }
             if *profile != next_profile {
                 *profile = next_profile;
                 Effects::msg(Msg::Internal(Internal::ProfileChanged))
@@ -302,12 +308,17 @@ pub fn update_profile<E: Env + 'static>(
                     ..
                 }),
             ) if loading_auth_request == auth_request => {
-                let next_profile = Profile {
+                let mut next_profile = Profile {
                     auth: Some(auth.to_owned()),
+                    saved_auths: profile.saved_auths.to_owned(),
                     addons: addons_result.to_owned().unwrap_or(OFFICIAL_ADDONS.clone()),
                     addons_locked: addons_result.is_err(),
                     settings: Settings::default(),
                 };
+                if let Some(current_auth) = profile.auth.as_ref() {
+                    next_profile.save_auth(current_auth.to_owned());
+                }
+                next_profile.save_auth(auth.to_owned());
                 if *profile != next_profile {
                     *profile = next_profile;
                     Effects::msg(Msg::Internal(Internal::ProfileChanged))
@@ -378,6 +389,8 @@ pub fn update_profile<E: Env + 'static>(
             Ok(user) => match &mut profile.auth {
                 Some(auth) if auth.user != *user => {
                     user.clone_into(&mut auth.user);
+                    let saved_auth = auth.to_owned();
+                    profile.save_auth(saved_auth);
                     Effects::msg(Msg::Event(Event::UserPulledFromAPI { uid: profile.uid() }))
                         .join(Effects::msg(Msg::Internal(Internal::ProfileChanged)))
                 }
@@ -386,6 +399,10 @@ pub fn update_profile<E: Env + 'static>(
                         Effects::msg(Msg::Event(Event::UserPulledFromAPI { uid: profile.uid() }));
                     if *overwritten {
                         profile.auth = Some(Auth {
+                            key: auth_key.clone(),
+                            user: user.clone(),
+                        });
+                        profile.save_auth(Auth {
                             key: auth_key.clone(),
                             user: user.clone(),
                         });

--- a/src/types/profile/profile.rs
+++ b/src/types/profile/profile.rs
@@ -20,6 +20,8 @@ pub type UID = Option<UserId>;
 #[serde(rename_all = "camelCase")]
 pub struct Profile {
     pub auth: Option<Auth>,
+    #[serde(default)]
+    pub saved_auths: Vec<Auth>,
     #[serde_as(deserialize_as = "UniqueVec<Vec<_>, DescriptorUniqueVecAdapter>")]
     pub addons: Vec<Descriptor>,
     /// This locking flag is raised when the API addon fetch request has failed
@@ -34,6 +36,7 @@ impl Default for Profile {
     fn default() -> Self {
         Profile {
             auth: None,
+            saved_auths: vec![],
             addons: OFFICIAL_ADDONS.to_owned(),
             addons_locked: false,
             settings: Settings::default(),
@@ -47,6 +50,17 @@ impl Profile {
     }
     pub fn auth_key(&self) -> Option<&AuthKey> {
         self.auth.as_ref().map(|auth| &auth.key)
+    }
+
+    pub fn save_auth(&mut self, auth: Auth) {
+        self.saved_auths
+            .retain(|saved_auth| saved_auth.user.id != auth.user.id);
+        self.saved_auths.insert(0, auth);
+    }
+
+    pub fn remove_saved_auth(&mut self, user_id: &UserId) {
+        self.saved_auths
+            .retain(|saved_auth| &saved_auth.user.id != user_id);
     }
 
     /// check whether the user has Trakt authentication token

--- a/src/unit_tests/ctx/authenticate.rs
+++ b/src/unit_tests/ctx/authenticate.rs
@@ -22,10 +22,10 @@ use futures::future;
 use std::any::Any;
 use stremio_derive::Model;
 
-fn user_fixture() -> User {
+fn user_fixture_with_id(id: &str, email: &str) -> User {
     User {
-        id: "user_id".into(),
-        email: "user_email".to_owned(),
+        id: id.into(),
+        email: email.to_owned(),
         fb_id: None,
         apple_id: None,
         avatar: None,
@@ -43,6 +43,10 @@ fn user_fixture() -> User {
     }
 }
 
+fn user_fixture() -> User {
+    user_fixture_with_id("user_id", "user_email")
+}
+
 fn auth_response_fixture() -> AuthResponse {
     AuthResponse {
         key: AuthKey("auth_key".to_owned()),
@@ -51,11 +55,13 @@ fn auth_response_fixture() -> AuthResponse {
 }
 
 fn profile_fixture() -> Profile {
+    let auth = Auth {
+        key: AuthKey("auth_key".to_owned()),
+        user: user_fixture(),
+    };
     Profile {
-        auth: Some(Auth {
-            key: AuthKey("auth_key".to_owned()),
-            user: user_fixture(),
-        }),
+        auth: Some(auth.to_owned()),
+        saved_auths: vec![auth],
         addons: vec![],
         ..Default::default()
     }
@@ -343,6 +349,100 @@ fn actionctx_authenticate_login_with_token() {
             ..Default::default()
         },
         "DatastoreGet request has been sent"
+    );
+}
+
+#[test]
+fn actionctx_authenticate_preserves_previous_auth() {
+    #[derive(Model, Clone, Default)]
+    #[model(TestEnv)]
+    struct TestModel {
+        ctx: Ctx,
+    }
+    fn fetch_handler(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+        match request {
+            Request {
+                url, method, body, ..
+            } if url == "https://api.strem.io/api/loginWithToken"
+                && method == "POST"
+                && body == "{\"type\":\"Auth\",\"type\":\"LoginWithToken\",\"token\":\"auth_key\"}" =>
+            {
+                future::ok(Box::new(APIResult::Ok(auth_response_fixture())) as Box<dyn Any + Send>).boxed_env()
+            }
+            Request {
+                url, method, body, ..
+            } if url == "https://api.strem.io/api/addonCollectionGet"
+                && method == "POST"
+                && body == "{\"type\":\"AddonCollectionGet\",\"authKey\":\"auth_key\",\"update\":true}" =>
+            {
+                future::ok(Box::new(APIResult::Ok(
+                    CollectionResponse {
+                        addons: vec![],
+                        last_modified: TestEnv::now(),
+                    },
+                )) as Box<dyn Any + Send>).boxed_env()
+            }
+            Request {
+                url, method, body, ..
+            } if url == "https://api.strem.io/api/datastoreGet"
+                && method == "POST"
+                && body == "{\"authKey\":\"auth_key\",\"collection\":\"libraryItem\",\"ids\":[],\"all\":true}" =>
+            {
+                future::ok(Box::new(APIResult::Ok(LibraryItemsResponse::new())) as Box<dyn Any + Send>).boxed_env()
+            }
+            _ => default_fetch_handler(request),
+        }
+    }
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+    let previous_auth = Auth {
+        key: AuthKey("previous_auth_key".to_owned()),
+        user: user_fixture_with_id("previous_user_id", "previous_user_email"),
+    };
+    let profile = Profile {
+        auth: Some(previous_auth.to_owned()),
+        saved_auths: vec![],
+        ..Default::default()
+    };
+    let expected_auth = Auth {
+        key: AuthKey("auth_key".to_owned()),
+        user: user_fixture(),
+    };
+    let expected_profile = Profile {
+        auth: Some(expected_auth.to_owned()),
+        saved_auths: vec![expected_auth, previous_auth],
+        addons: vec![],
+        ..Default::default()
+    };
+    let ctx = Ctx::new(
+        profile,
+        LibraryBucket::default(),
+        StreamsBucket::default(),
+        ServerUrlsBucket::new::<TestEnv>(None),
+        NotificationsBucket::new::<TestEnv>(None, vec![]),
+        SearchHistoryBucket::default(),
+        DismissedEventsBucket::default(),
+    );
+    let (runtime, _rx) = Runtime::<TestEnv, _>::new(TestModel { ctx }, vec![], 1000);
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Ctx(ActionCtx::Authenticate(AuthRequest::LoginWithToken {
+                token: "auth_key".into(),
+            })),
+        })
+    });
+
+    assert_eq!(
+        runtime.model().unwrap().ctx.profile,
+        expected_profile,
+        "previous profile auth is preserved in saved auths"
+    );
+    assert_eq!(
+        serde_json::from_str::<Profile>(STORAGE.read().unwrap().get(PROFILE_STORAGE_KEY).unwrap())
+            .unwrap(),
+        expected_profile,
+        "previous profile auth is persisted in saved auths"
     );
 }
 

--- a/src/unit_tests/ctx/logout.rs
+++ b/src/unit_tests/ctx/logout.rs
@@ -42,28 +42,55 @@ fn actionctx_logout() {
             _ => default_fetch_handler(request),
         }
     }
-    let profile = Profile {
-        auth: Some(Auth {
-            key: AuthKey("auth_key".to_owned()),
-            user: User {
-                id: "user_id".into(),
-                email: "user_email".to_owned(),
-                fb_id: None,
-                apple_id: None,
-                avatar: None,
-                last_modified: TestEnv::now(),
-                date_registered: TestEnv::now(),
-                trakt: None,
-                premium_expire: None,
-                gdpr_consent: GDPRConsent {
-                    tos: true,
-                    privacy: true,
-                    marketing: true,
-                    from: Some("tests".to_owned()),
-                },
-                ..Default::default()
+    let current_auth = Auth {
+        key: AuthKey("auth_key".to_owned()),
+        user: User {
+            id: "user_id".into(),
+            email: "user_email".to_owned(),
+            fb_id: None,
+            apple_id: None,
+            avatar: None,
+            last_modified: TestEnv::now(),
+            date_registered: TestEnv::now(),
+            trakt: None,
+            premium_expire: None,
+            gdpr_consent: GDPRConsent {
+                tos: true,
+                privacy: true,
+                marketing: true,
+                from: Some("tests".to_owned()),
             },
-        }),
+            ..Default::default()
+        },
+    };
+    let saved_auth = Auth {
+        key: AuthKey("other_auth_key".to_owned()),
+        user: User {
+            id: "other_user_id".into(),
+            email: "other_user_email".to_owned(),
+            fb_id: None,
+            apple_id: None,
+            avatar: None,
+            last_modified: TestEnv::now(),
+            date_registered: TestEnv::now(),
+            trakt: None,
+            premium_expire: None,
+            gdpr_consent: GDPRConsent {
+                tos: true,
+                privacy: true,
+                marketing: true,
+                from: Some("tests".to_owned()),
+            },
+            ..Default::default()
+        },
+    };
+    let expected_profile = Profile {
+        saved_auths: vec![saved_auth.to_owned()],
+        ..Default::default()
+    };
+    let profile = Profile {
+        auth: Some(current_auth.to_owned()),
+        saved_auths: vec![current_auth, saved_auth],
         ..Default::default()
     };
     let library = LibraryBucket {
@@ -107,7 +134,7 @@ fn actionctx_logout() {
     });
     assert_eq!(
         runtime.model().unwrap().ctx.profile,
-        Default::default(),
+        expected_profile,
         "profile updated successfully in memory"
     );
     assert_eq!(
@@ -121,7 +148,7 @@ fn actionctx_logout() {
             .unwrap()
             .get(PROFILE_STORAGE_KEY)
             .is_some_and(|data| {
-                serde_json::from_str::<Profile>(data).unwrap() == Default::default()
+                serde_json::from_str::<Profile>(data).unwrap() == expected_profile
             }),
         "profile updated successfully in storage"
     );

--- a/src/unit_tests/serde/profile.rs
+++ b/src/unit_tests/serde/profile.rs
@@ -8,12 +8,14 @@ fn profile() {
         &vec![
             Profile {
                 auth: Some(Auth::default()),
+                saved_auths: vec![Auth::default()],
                 addons: vec![],
                 addons_locked: false,
                 settings: Settings::default(),
             },
             Profile {
                 auth: None,
+                saved_auths: vec![],
                 addons: vec![],
                 addons_locked: false,
                 settings: Settings::default(),
@@ -25,13 +27,16 @@ fn profile() {
                 Token::Seq { len: Some(2) },
                 Token::Struct {
                     name: "Profile",
-                    len: 4,
+                    len: 5,
                 },
                 Token::Str("auth"),
                 Token::Some,
             ],
             Auth::default_tokens(),
+            vec![Token::Str("savedAuths"), Token::Seq { len: Some(1) }],
+            Auth::default_tokens(),
             vec![
+                Token::SeqEnd,
                 Token::Str("addons"),
                 Token::Seq { len: Some(0) },
                 Token::SeqEnd,
@@ -44,10 +49,13 @@ fn profile() {
                 Token::StructEnd,
                 Token::Struct {
                     name: "Profile",
-                    len: 4,
+                    len: 5,
                 },
                 Token::Str("auth"),
                 Token::None,
+                Token::Str("savedAuths"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
                 Token::Str("addons"),
                 Token::Seq { len: Some(0) },
                 Token::SeqEnd,
@@ -63,6 +71,7 @@ fn profile() {
     assert_de_tokens(
         &Profile {
             auth: None,
+            saved_auths: vec![],
             addons: vec![],
             addons_locked: false,
             settings: Settings::default(),


### PR DESCRIPTION
## Summary
- Add `savedAuths` to `Profile` so clients can retain multiple authenticated accounts.
- Save successful auths and seed the previous active auth when switching from a legacy single-auth profile.
- Preserve non-current saved auths on logout while removing the invalidated current session.

Refs #995

## Tests
- `DEVELOPER_DIR=/Library/Developer/CommandLineTools cargo fmt --all -- --check`
- `DEVELOPER_DIR=/Library/Developer/CommandLineTools cargo test`
- `DEVELOPER_DIR=/Library/Developer/CommandLineTools cargo test -p stremio-core --lib --features derive,analytics -- --test-threads=1`
- `DEVELOPER_DIR=/Library/Developer/CommandLineTools cargo test -p stremio-core-web -- --test-threads=1`
- `CARGO_BUILD_JOBS=1 DEVELOPER_DIR=/Library/Developer/CommandLineTools cargo clippy --all --no-deps -- -D warnings`
- `DEVELOPER_DIR=/Library/Developer/CommandLineTools cargo build`

## Notes
- This adds core state support for account switching; UI account picker work still needs to consume `savedAuths`.
- Not run locally: `wasm-pack test --chromedriver "$(which chromedriver)" --chrome --headless` because local `wasm-pack`, `chromedriver`, and Chrome/Chromium CLI are unavailable.