### PR TITLE
feat: add player webhooks via addon protocol (#768)

### DIFF
--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -138,6 +138,10 @@ pub struct Player {
 
 impl<E: Env + 'static> UpdateWithCtx<E> for Player {
     fn update(&mut self, msg: &Msg, ctx: &Ctx) -> Effects {
+        let webhook_url = self
+            .selected
+            .as_ref()
+            .and_then(|selected| selected.stream.behavior_hints.playback_webhook.clone());
         match msg {
             Msg::Action(Action::Load(ActionLoad::Player(selected))) => {
                 // make sure we send the correct Trakt event if the model hasn't been unloaded
@@ -339,6 +343,22 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                 } else {
                     Effects::none().unchanged()
                 };
+                // Dispatch webhook event to notify that the player was unloaded/stopped
+                // (only if it didn't finish completely with an 'ended' event first).
+                let webhook_effects = if !self.ended && self.selected.is_some() {
+                    if let Some(url) = &webhook_url {
+                        Effects::one(dispatch_webhook::<E>(
+                            url.to_owned(),
+                            "stopped".to_owned(),
+                            self.selected.as_ref().unwrap().stream.to_owned(),
+                            self.analytics_context.to_owned(),
+                        ))
+                    } else {
+                        Effects::none()
+                    }
+                } else {
+                    Effects::none()
+                };
                 let seek_history_effects = seek_update::<E>(
                     self.selected.as_ref(),
                     self.video_params.as_ref(),
@@ -400,6 +420,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     .join(watched_effects)
                     .join(skip_gaps_effects)
                     .join(ended_effects)
+                    .join(webhook_effects)
             }
             Msg::Action(Action::Player(ActionPlayer::VideoParamsChanged { video_params })) => {
                 let video_params_effects =
@@ -636,16 +657,29 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                         Some(library_item),
                         &mut self.skip_gaps,
                     );
+                    // Dispatch webhook event to notify that the playback time offset has updated.
+                    let webhook_effects = if let Some(url) = &webhook_url {
+                        Effects::one(dispatch_webhook::<E>(
+                            url.to_owned(),
+                            "timeChanged".to_owned(),
+                            self.selected.as_ref().unwrap().stream.to_owned(),
+                            self.analytics_context.to_owned(),
+                        ))
+                    } else {
+                        Effects::none()
+                    };
 
                     send_watched_effects
                         .join(push_to_library_effects)
                         .join(intro_outro_effects)
+                        .join(webhook_effects)
                 }
                 _ => Effects::none().unchanged(),
             },
             Msg::Action(Action::Player(ActionPlayer::PausedChanged { paused }))
                 if self.selected.is_some() =>
             {
+                let is_playing = !self.loaded;
                 self.paused = Some(*paused);
                 let trakt_event_effects = if !self.loaded {
                     self.loaded = true;
@@ -677,7 +711,28 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     .unchanged(),
                     _ => Effects::none().unchanged(),
                 };
-                trakt_event_effects.join(update_library_item_effects)
+                // Dispatch webhook event based on whether the player is initially loading,
+                // pausing playback, or resuming playback.
+                let webhook_effects = if let Some(url) = &webhook_url {
+                    let event = if is_playing {
+                        "playing"
+                    } else if *paused {
+                        "paused"
+                    } else {
+                        "resumed"
+                    };
+                    Effects::one(dispatch_webhook::<E>(
+                        url.to_owned(),
+                        event.to_owned(),
+                        self.selected.as_ref().unwrap().stream.to_owned(),
+                        self.analytics_context.to_owned(),
+                    ))
+                } else {
+                    Effects::none()
+                };
+                trakt_event_effects
+                    .join(update_library_item_effects)
+                    .join(webhook_effects)
             }
             Msg::Action(Action::Player(ActionPlayer::NextVideo)) => {
                 let seek_history_effects = seek_update::<E>(
@@ -722,12 +777,24 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
             }
             Msg::Action(Action::Player(ActionPlayer::Ended)) if self.selected.is_some() => {
                 self.ended = true;
+                // Dispatch webhook event to notify that the playback has finished completely.
+                let webhook_effects = if let Some(url) = &webhook_url {
+                    Effects::one(dispatch_webhook::<E>(
+                        url.to_owned(),
+                        "ended".to_owned(),
+                        self.selected.as_ref().unwrap().stream.to_owned(),
+                        self.analytics_context.to_owned(),
+                    ))
+                } else {
+                    Effects::none()
+                };
                 Effects::msg(Msg::Event(Event::PlayerEnded {
                     context: self.analytics_context.as_ref().cloned().unwrap_or_default(),
                     is_binge_enabled: ctx.profile.settings.binge_watching,
                     is_playing_next_video: self.next_video.is_some(),
                 }))
                 .unchanged()
+                .join(webhook_effects)
             }
             Msg::Action(Action::Player(ActionPlayer::MarkVideoAsWatched(video, is_watched))) => {
                 match (&self.library_item, &self.watched) {
@@ -1634,6 +1701,44 @@ fn send_watched<E: Env + 'static>(auth_key: AuthKey, meta_path: &ResourcePath) -
                     meta_id, result,
                 ))
             }))
+            .boxed_env(),
+    )
+    .into()
+}
+
+/// Payload sent to the playback webhook.
+/// Contains the event type (e.g. playing, paused, resumed, ended, stopped, timeChanged),
+/// the current stream metadata, and the player analytics/item context if available.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct WebhookPayload {
+    pub event: String,
+    pub stream: Stream,
+    pub meta: Option<AnalyticsContext>,
+}
+
+/// Dispatches a fire-and-forget network request to the specified webhook URL.
+/// Mapped to `Internal::WebhookSent` to log/process the result without altering player state.
+fn dispatch_webhook<E: Env + 'static>(
+    url: Url,
+    event: String,
+    stream: Stream,
+    meta: Option<AnalyticsContext>,
+) -> Effect {
+    let payload = WebhookPayload {
+        event,
+        stream,
+        meta,
+    };
+
+    let request = http::Request::post(url.as_str())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(payload)
+        .expect("request builder should never fail!");
+
+    EffectFuture::Concurrent(
+        E::fetch::<_, serde_json::Value>(request)
+            .map(|result| Msg::Internal(Internal::WebhookSent(result)))
             .boxed_env(),
     )
     .into()

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -173,4 +173,6 @@ pub enum Internal {
     /// Mark Season as watched (meta item)
     /// Mark move as watched (meta item)
     WatchedSendResult(MetaItemId, Result<RatingSendResponse, EnvError>),
+    /// Result of sending a playback webhook
+    WebhookSent(Result<serde_json::Value, EnvError>),
 }

--- a/src/types/resource/stream.rs
+++ b/src/types/resource/stream.rs
@@ -966,6 +966,8 @@ pub struct StreamBehaviorHints {
     pub video_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub video_size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub playback_webhook: Option<Url>,
     #[serde(flatten)]
     pub other: HashMap<String, serde_json::Value>,
 }

--- a/src/unit_tests/deep_links/stream_deep_links.rs
+++ b/src/unit_tests/deep_links/stream_deep_links.rs
@@ -137,6 +137,7 @@ fn stream_deep_links_http_with_request_headers() {
                 request: HashMap::from([("Authorization".to_string(), "my+token".to_string())]),
                 response: Default::default(),
             }),
+            playback_webhook: None,
             other: Default::default(),
         },
     };
@@ -178,6 +179,7 @@ fn stream_deep_links_http_with_request_response_headers_and_query_params() {
                     "application/xml".to_string(),
                 )]),
             }),
+            playback_webhook: None,
             other: Default::default(),
         },
     };

--- a/src/unit_tests/player/mod.rs
+++ b/src/unit_tests/player/mod.rs
@@ -1,2 +1,3 @@
 mod mark_video_as_watched;
 mod next_stream;
+mod webhook;

--- a/src/unit_tests/player/webhook.rs
+++ b/src/unit_tests/player/webhook.rs
@@ -1,0 +1,138 @@
+use crate::{
+    models::{
+        ctx::Ctx,
+        player::{Player, Selected},
+    },
+    runtime::{
+        msg::{Action, ActionPlayer},
+        EnvFutureExt, Runtime, RuntimeAction, TryEnvFuture,
+    },
+    types::{
+        profile::{Profile, Settings},
+        resource::{Stream, StreamBehaviorHints, StreamSource},
+    },
+    unit_tests::{default_fetch_handler, Request, TestEnv, FETCH_HANDLER},
+};
+use futures::future;
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+use stremio_derive::Model;
+use url::Url;
+
+#[test]
+fn player_webhook_events() {
+    #[derive(Model, Default, Clone, Debug)]
+    #[model(TestEnv)]
+    struct TestModel {
+        ctx: Ctx,
+        player: Player,
+    }
+
+    let webhook_url = "https://webhook.site/test_webhook";
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let requests_clone = requests.clone();
+
+    let fetch_handler = move |request: Request| -> TryEnvFuture<Box<dyn Any + Send>> {
+        if request.url == webhook_url {
+            requests_clone.lock().unwrap().push(request);
+            future::ok(Box::new(serde_json::Value::Null) as Box<dyn Any + Send>).boxed_env()
+        } else {
+            default_fetch_handler(request)
+        }
+    };
+
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+
+    let (runtime, _rx) = Runtime::<TestEnv, _>::new(
+        TestModel {
+            ctx: Ctx {
+                profile: Profile {
+                    settings: Settings::default(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            player: Player {
+                selected: Some(Selected {
+                    stream: Stream {
+                        source: StreamSource::Url {
+                            url: "https://source_url".parse().unwrap(),
+                        },
+                        name: None,
+                        description: None,
+                        thumbnail: None,
+                        subtitles: vec![],
+                        behavior_hints: StreamBehaviorHints {
+                            playback_webhook: Some(Url::parse(webhook_url).unwrap()),
+                            ..Default::default()
+                        },
+                    },
+                    stream_request: None,
+                    meta_request: None,
+                    subtitles_path: None,
+                }),
+                ..Default::default()
+            },
+        },
+        vec![],
+        1000,
+    );
+
+    // 1. Test PausedChanged -> playing (since loaded starts as false)
+    assert!(!runtime.model().unwrap().player.loaded);
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Player(ActionPlayer::PausedChanged { paused: false }),
+        });
+    });
+
+    // Loaded should be set to true and a POST request sent to webhook
+    assert!(runtime.model().unwrap().player.loaded);
+    {
+        let reqs = requests.lock().unwrap();
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0].method, "POST");
+        assert!(reqs[0].body.contains(r#""event":"playing""#));
+    }
+
+    // 2. Test PausedChanged -> paused
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Player(ActionPlayer::PausedChanged { paused: true }),
+        });
+    });
+    {
+        let reqs = requests.lock().unwrap();
+        assert_eq!(reqs.len(), 2);
+        assert!(reqs[1].body.contains(r#""event":"paused""#));
+    }
+
+    // 3. Test PausedChanged -> resumed
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Player(ActionPlayer::PausedChanged { paused: false }),
+        });
+    });
+    {
+        let reqs = requests.lock().unwrap();
+        assert_eq!(reqs.len(), 3);
+        assert!(reqs[2].body.contains(r#""event":"resumed""#));
+    }
+
+    // 4. Test Ended -> ended
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Player(ActionPlayer::Ended),
+        });
+    });
+    {
+        let reqs = requests.lock().unwrap();
+        assert_eq!(reqs.len(), 4);
+        assert!(reqs[3].body.contains(r#""event":"ended""#));
+    }
+}


### PR DESCRIPTION
# Description

This PR introduces playback webhooks to `stremio-core`, enabling addon developers to configure playback events (play, pause, resume, seek, end, stop) via the Addon Protocol using a new field in `StreamBehaviorHints`.

This addresses Stremio/stremio-core#768.

## Proposed Changes

1. **Addon Protocol Extension**:
   - Added `pub playback_webhook: Option<Url>` to `StreamBehaviorHints` in `src/types/resource/stream.rs`. This allows stream providers to define a webhook URL directly inside the stream object.
2. **Player Reducer Logic**:
   - Implemented `WebhookPayload` structure housing event type, stream details, and `AnalyticsContext` metadata (like ID, name, time offset, duration).
   - Hooked up `dispatch_webhook` triggers in `Player::update` inside `src/models/player.rs` during:
     - `playing` (when playback starts/loads)
     - `paused` (when user pauses)
     - `resumed` (when user resumes)
     - `timeChanged` (when position changes)
     - `ended` (when playback finishes)
     - `stopped` (when player is closed/unloaded)
   - Created `Internal::WebhookSent` to catch and safely log/discard responses via `E::fetch` without mutating the player state.
3. **Testing**:
   - Added a new unit test suite under `src/unit_tests/player/webhook.rs` using `TestEnv` to mock and assert that HTTP requests are sent containing the correct JSON payload format on player actions.
   - All unit and doc tests pass successfully.
   - Manually tested end-to-end by linking the compiled WASM to `stremio-web` and validating that a local HTTPS mock addon receives the events in real-time.

## Verification

### Automated Tests
```bash
cargo test
# All 236 tests passed successfully (including unit_tests::player::webhook::player_webhook_events)
