### PR TITLE
Refactor external player requests

### DIFF
--- a/src/deep_links/mod.rs
+++ b/src/deep_links/mod.rs
@@ -1,5 +1,4 @@
 use percent_encoding::utf8_percent_encode;
-use regex::Regex;
 use serde::Serialize;
 use url::Url;
 
@@ -25,22 +24,57 @@ pub use error_link::ErrorLink;
 
 mod error_link;
 
+#[derive(Clone, Copy, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ExternalPlayerId {
+    Choose,
+    Vlc,
+    Mxplayer,
+    Justplayer,
+    Outplayer,
+    Infuse,
+    Vidhub,
+    Iina,
+    Mpv,
+    Moonplayer,
+    M3u,
+}
+
+#[derive(Clone, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalPlayerRequest {
+    pub player_id: ExternalPlayerId,
+    pub url: Url,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_name: Option<String>,
+}
+
+impl ExternalPlayerRequest {
+    fn new(player_id: ExternalPlayerId, url: Url) -> Self {
+        Self {
+            player_id,
+            url,
+            file_name: None,
+        }
+    }
+}
+
 #[derive(Default, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct OpenPlayerLink {
-    pub ios: Option<String>,
-    pub android: Option<String>,
-    pub windows: Option<String>,
-    pub macos: Option<String>,
-    pub linux: Option<String>,
-    pub tizen: Option<String>,
-    pub webos: Option<String>,
-    pub chromeos: Option<String>,
-    pub roku: Option<String>,
+    pub ios: Option<ExternalPlayerRequest>,
+    pub android: Option<ExternalPlayerRequest>,
+    pub windows: Option<ExternalPlayerRequest>,
+    pub macos: Option<ExternalPlayerRequest>,
+    pub linux: Option<ExternalPlayerRequest>,
+    pub tizen: Option<ExternalPlayerRequest>,
+    pub webos: Option<ExternalPlayerRequest>,
+    pub chromeos: Option<ExternalPlayerRequest>,
+    pub roku: Option<ExternalPlayerRequest>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// VisionOS
-    pub visionos: Option<String>,
-    pub tvos: Option<String>,
+    pub visionos: Option<ExternalPlayerRequest>,
+    pub tvos: Option<ExternalPlayerRequest>,
 }
 
 #[derive(Default, Serialize, Debug, PartialEq, Eq)]
@@ -113,8 +147,6 @@ impl From<(&Stream<ConvertedStreamSource>, Option<&Url>, &Settings)> for Externa
             &Settings,
         ),
     ) -> Self {
-        let http_regex = Regex::new(r"https?://").unwrap();
-
         let stream_urls = StreamUrls::new(stream.clone(), streaming_server_url);
         let download = stream_urls.download_url.as_ref().map(ToString::to_string);
         let magnet = stream_urls.magnet_url.as_ref().map(ToString::to_string);
@@ -122,86 +154,86 @@ impl From<(&Stream<ConvertedStreamSource>, Option<&Url>, &Settings)> for Externa
         let playlist = stream_urls.m3u_data_uri.clone();
         let file_name = playlist.as_ref().map(|_| "playlist.m3u".to_owned());
 
-        let open_player = match &streaming {
-            Some(url) => {
-                let url_encoded = utf8_percent_encode(url.as_str(), URI_COMPONENT_ENCODE_SET);
-
-                match settings.player_type.as_ref() {
-                Some(player_type) => match player_type.as_str() {
-                    "choose" => Some(OpenPlayerLink {
-                        android: Some(format!(
-                            "{}#Intent;type=video/any;scheme=https;end",
-                            http_regex.replace(url.as_str(), "intent://"),
-                        )),
+        let open_player = streaming.as_ref().and_then(|url| {
+            let request = |player_id| ExternalPlayerRequest::new(player_id, url.to_owned());
+            match settings.player_type.as_deref() {
+                Some("choose") => Some(OpenPlayerLink {
+                    android: Some(request(ExternalPlayerId::Choose)),
+                    ..Default::default()
+                }),
+                Some("vlc") => {
+                    let request = request(ExternalPlayerId::Vlc);
+                    Some(OpenPlayerLink {
+                        ios: Some(request.clone()),
+                        visionos: Some(request.clone()),
+                        android: Some(request),
                         ..Default::default()
-                    }),
-                    "vlc" => Some(OpenPlayerLink {
-                        ios: Some(format!("vlc-x-callback://x-callback-url/stream?url={url_encoded}")),
-                        visionos: Some(format!("vlc-x-callback://x-callback-url/stream?url={url_encoded}")),
-                        android: Some(format!(
-                            "{}#Intent;package=org.videolan.vlc;type=video;scheme=https;end",
-                            http_regex.replace(url.as_str(), "intent://"),
-                        )),
+                    })
+                }
+                Some("mxplayer") => Some(OpenPlayerLink {
+                    android: Some(request(ExternalPlayerId::Mxplayer)),
+                    ..Default::default()
+                }),
+                Some("justplayer") => Some(OpenPlayerLink {
+                    android: Some(request(ExternalPlayerId::Justplayer)),
+                    ..Default::default()
+                }),
+                Some("outplayer") => {
+                    let request = request(ExternalPlayerId::Outplayer);
+                    Some(OpenPlayerLink {
+                        ios: Some(request.clone()),
+                        visionos: Some(request),
                         ..Default::default()
-                    }),
-                    "mxplayer" => Some(OpenPlayerLink {
-                        android: Some(format!(
-                            "{}#Intent;package=com.mxtech.videoplayer.ad;type=video;scheme=https;end",
-                            http_regex.replace(url.as_str(), "intent://"),
-                        )),
+                    })
+                }
+                Some("infuse") => {
+                    let request = request(ExternalPlayerId::Infuse);
+                    Some(OpenPlayerLink {
+                        ios: Some(request.clone()),
+                        macos: Some(request.clone()),
+                        visionos: Some(request.clone()),
+                        tvos: Some(request),
                         ..Default::default()
-                    }),
-                    "justplayer" => Some(OpenPlayerLink {
-                        android: Some(format!(
-                            "{}#Intent;package=com.brouken.player;type=video;scheme=https;end",
-                            http_regex.replace(url.as_str(), "intent://"),
-                        )),
+                    })
+                }
+                Some("vidhub") => {
+                    let request = request(ExternalPlayerId::Vidhub);
+                    Some(OpenPlayerLink {
+                        ios: Some(request.clone()),
+                        macos: Some(request),
                         ..Default::default()
-                    }),
-                    "outplayer" => Some(OpenPlayerLink {
-                        ios: Some(http_regex.replace(url.as_str(), "outplayer://").to_string()),
-                        visionos: Some(http_regex.replace(url.as_str(), "outplayer://").to_string()),
+                    })
+                }
+                Some("iina") => Some(OpenPlayerLink {
+                    macos: Some(request(ExternalPlayerId::Iina)),
+                    ..Default::default()
+                }),
+                Some("mpv") => Some(OpenPlayerLink {
+                    macos: Some(request(ExternalPlayerId::Mpv)),
+                    ..Default::default()
+                }),
+                Some("moonplayer") => Some(OpenPlayerLink {
+                    visionos: Some(request(ExternalPlayerId::Moonplayer)),
+                    ..Default::default()
+                }),
+                Some("m3u") => {
+                    let request = ExternalPlayerRequest {
+                        player_id: ExternalPlayerId::M3u,
+                        url: Url::parse(playlist.as_ref()?).ok()?,
+                        file_name: file_name.clone(),
+                    };
+                    Some(OpenPlayerLink {
+                        linux: Some(request.clone()),
+                        windows: Some(request.clone()),
+                        macos: Some(request.clone()),
+                        android: Some(request.clone()),
+                        ios: Some(request),
                         ..Default::default()
-                    }),
-                    "infuse" => Some(OpenPlayerLink {
-                        ios: Some(format!("infuse://x-callback-url/play?x-success=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D1&x-error=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D0&url={url_encoded}")),
-                        macos: Some(format!("infuse://x-callback-url/play?x-success=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D1&x-error=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D0&url={url_encoded}")),
-                        visionos: Some(format!("infuse://x-callback-url/play?x-success=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D1&x-error=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D0&url={url_encoded}")),
-                        tvos: Some(format!("infuse://x-callback-url/play?x-success=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D1&x-error=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D0&url={url_encoded}")),
-                       ..Default::default()
-                    }),
-                    "vidhub" => Some(OpenPlayerLink {
-                        ios: Some(format!("open-vidhub://x-callback-url/open?on-success=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D1&on-failed=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D0&url={url_encoded}")),
-                        macos: Some(format!("open-vidhub://x-callback-url/open?on-success=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D1&on-failed=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D0&url={url_encoded}")),
-                        ..Default::default()
-                    }),
-                    "iina" => Some(OpenPlayerLink {
-                        macos: Some(format!("iina://weblink?url={url_encoded}")),
-                       ..Default::default()
-                    }),
-                    "mpv" => Some(OpenPlayerLink {
-                        macos: Some(format!("mpv://{url}")),
-                       ..Default::default()
-                    }),
-                    "moonplayer" => Some(OpenPlayerLink {
-                        visionos: Some(format!("moonplayer://open?url={url}")),
-                        ..Default::default()
-                    }),
-                    "m3u" => Some(OpenPlayerLink {
-                        linux: playlist.to_owned(),
-                        windows: playlist.to_owned(),
-                        macos: playlist.to_owned(),
-                        android: playlist.to_owned(),
-                        ios: playlist.to_owned(),
-                       ..Default::default()
-                    }),
-                    _ => None,
-                },
-                None => None,
+                    })
+                }
+                _ => None,
             }
-            }
-            None => None,
-        };
+        });
         let (web, android_tv, tizen, webos) = match &stream.source {
             ConvertedStreamSource::External {
                 external_url,

--- a/src/unit_tests/deep_links/external_player_link.rs
+++ b/src/unit_tests/deep_links/external_player_link.rs
@@ -1,9 +1,10 @@
 use crate::constants::{BASE64, URI_COMPONENT_ENCODE_SET};
-use crate::deep_links::ExternalPlayerLink;
+use crate::deep_links::{ExternalPlayerId, ExternalPlayerLink, ExternalPlayerRequest};
 use crate::types::profile::Settings;
 use crate::types::resource::{Stream, StreamSource};
 use base64::Engine;
 use percent_encoding::utf8_percent_encode;
+use serde_json::json;
 use std::str::FromStr;
 use url::Url;
 
@@ -13,6 +14,14 @@ const MAGNET_STR_URL: &str = "magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d870
 const HTTP_STR_URL: &str = "http://domain.root/path";
 const BASE64_HTTP_URL: &str = "data:application/octet-stream;charset=utf-8;base64,I0VYVE0zVQojRVhUSU5GOjAKaHR0cDovL2RvbWFpbi5yb290L3BhdGg=";
 const STREAMING_SERVER_URL: &str = "http://127.0.0.1:11470";
+
+fn expected_request(player_id: ExternalPlayerId) -> ExternalPlayerRequest {
+    ExternalPlayerRequest {
+        player_id,
+        url: Url::parse("http://example.com/stream").unwrap(),
+        file_name: None,
+    }
+}
 
 #[test]
 fn external_player_link_magnet() {
@@ -197,15 +206,10 @@ fn external_player_link_with_vlc_player() {
 
     assert_eq!(
         open_player.android,
-        Some("intent://example.com/stream#Intent;package=org.videolan.vlc;type=video;scheme=https;end".to_string())
+        Some(expected_request(ExternalPlayerId::Vlc))
     );
-    assert_eq!(
-        open_player.ios,
-        Some(
-            "vlc-x-callback://x-callback-url/stream?url=http%3A%2F%2Fexample.com%2Fstream"
-                .to_string()
-        )
-    );
+    assert_eq!(open_player.ios, open_player.android);
+    assert_eq!(open_player.visionos, open_player.android);
 }
 
 #[test]
@@ -233,7 +237,7 @@ fn external_player_link_with_mxplayer() {
 
     assert_eq!(
         epl.open_player.unwrap().android,
-        Some("intent://example.com/stream#Intent;package=com.mxtech.videoplayer.ad;type=video;scheme=https;end".to_string())
+        Some(expected_request(ExternalPlayerId::Mxplayer))
     );
 }
 
@@ -262,7 +266,7 @@ fn external_player_link_with_justplayer() {
 
     assert_eq!(
         epl.open_player.unwrap().android,
-        Some("intent://example.com/stream#Intent;package=com.brouken.player;type=video;scheme=https;end".to_string())
+        Some(expected_request(ExternalPlayerId::Justplayer))
     );
 }
 
@@ -291,7 +295,7 @@ fn external_player_link_with_outplayer() {
 
     assert_eq!(
         epl.open_player.unwrap().ios,
-        Some("outplayer://example.com/stream".to_string())
+        Some(expected_request(ExternalPlayerId::Outplayer))
     );
 }
 
@@ -322,8 +326,11 @@ fn external_player_link_with_infuse() {
 
     assert_eq!(
         open_player.ios,
-        Some("infuse://x-callback-url/play?x-success=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D1&x-error=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D0&url=http%3A%2F%2Fexample.com%2Fstream".to_string())
+        Some(expected_request(ExternalPlayerId::Infuse))
     );
+    assert_eq!(open_player.macos, open_player.ios);
+    assert_eq!(open_player.visionos, open_player.ios);
+    assert_eq!(open_player.tvos, open_player.ios);
 }
 
 #[test]
@@ -353,9 +360,125 @@ fn external_player_link_and_callback_with_vidhub() {
 
     assert_eq!(
         open_player.ios,
-        Some(
-            "open-vidhub://x-callback-url/open?on-success=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D1&on-failed=stremio%3A%2F%2F%2Fplayer%3FexternalPlayerSuccess%3D0&url=http%3A%2F%2Fexample.com%2Fstream"
-                .to_string()
-        )
+        Some(expected_request(ExternalPlayerId::Vidhub))
     );
+    assert_eq!(open_player.macos, open_player.ios);
+}
+
+#[test]
+fn external_player_link_serializes_typed_macos_request() {
+    let stream = Stream {
+        source: StreamSource::Url {
+            url: Url::from_str("http://example.com/stream").unwrap(),
+        },
+        name: None,
+        description: None,
+        thumbnail: None,
+        subtitles: vec![],
+        behavior_hints: Default::default(),
+    };
+    let streaming_server_url = Some(Url::parse(STREAMING_SERVER_URL).unwrap());
+
+    for (player_type, player_id) in [
+        ("iina", ExternalPlayerId::Iina),
+        ("mpv", ExternalPlayerId::Mpv),
+        ("infuse", ExternalPlayerId::Infuse),
+    ] {
+        let settings = Settings {
+            player_type: Some(player_type.to_owned()),
+            streaming_server_url: Url::parse(STREAMING_SERVER_URL).unwrap(),
+            ..Default::default()
+        };
+        let request = ExternalPlayerLink::from((&stream, streaming_server_url.as_ref(), &settings))
+            .open_player
+            .unwrap()
+            .macos
+            .unwrap();
+
+        assert_eq!(request, expected_request(player_id));
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
+            json!({
+                "playerId": player_type,
+                "url": "http://example.com/stream"
+            })
+        );
+    }
+}
+
+#[test]
+fn external_player_link_serializes_typed_platform_requests() {
+    let stream = Stream {
+        source: StreamSource::Url {
+            url: Url::from_str("http://example.com/stream").unwrap(),
+        },
+        name: None,
+        description: None,
+        thumbnail: None,
+        subtitles: vec![],
+        behavior_hints: Default::default(),
+    };
+    let streaming_server_url = Some(Url::parse(STREAMING_SERVER_URL).unwrap());
+
+    let choose = ExternalPlayerLink::from((
+        &stream,
+        streaming_server_url.as_ref(),
+        &Settings {
+            player_type: Some("choose".to_owned()),
+            streaming_server_url: Url::parse(STREAMING_SERVER_URL).unwrap(),
+            ..Default::default()
+        },
+    ))
+    .open_player
+    .unwrap();
+    assert_eq!(
+        choose.android,
+        Some(expected_request(ExternalPlayerId::Choose))
+    );
+
+    let moonplayer = ExternalPlayerLink::from((
+        &stream,
+        streaming_server_url.as_ref(),
+        &Settings {
+            player_type: Some("moonplayer".to_owned()),
+            streaming_server_url: Url::parse(STREAMING_SERVER_URL).unwrap(),
+            ..Default::default()
+        },
+    ))
+    .open_player
+    .unwrap();
+    assert_eq!(
+        moonplayer.visionos,
+        Some(expected_request(ExternalPlayerId::Moonplayer))
+    );
+}
+
+#[test]
+fn external_player_link_serializes_typed_m3u_request_for_desktop_platforms() {
+    let stream = Stream {
+        source: StreamSource::Url {
+            url: Url::from_str(HTTP_STR_URL).unwrap(),
+        },
+        name: None,
+        description: None,
+        thumbnail: None,
+        subtitles: vec![],
+        behavior_hints: Default::default(),
+    };
+    let streaming_server_url = Some(Url::parse(STREAMING_SERVER_URL).unwrap());
+    let settings = Settings {
+        player_type: Some("m3u".to_owned()),
+        streaming_server_url: Url::parse(STREAMING_SERVER_URL).unwrap(),
+        ..Default::default()
+    };
+    let open_player = ExternalPlayerLink::from((&stream, streaming_server_url.as_ref(), &settings))
+        .open_player
+        .unwrap();
+    let request = open_player.macos.unwrap();
+
+    assert_eq!(request.player_id, ExternalPlayerId::M3u);
+    assert_eq!(request.url.as_str(), BASE64_HTTP_URL);
+    assert_eq!(request.file_name.as_deref(), Some("playlist.m3u"));
+    assert_eq!(open_player.windows, Some(request.clone()));
+    assert_eq!(open_player.linux, Some(request));
 }

--- a/src/unit_tests/deep_links/library_item_deep_links.rs
+++ b/src/unit_tests/deep_links/library_item_deep_links.rs
@@ -3,8 +3,9 @@ use once_cell::sync::Lazy;
 use stremio_serde_hex::{SerHex, Strict};
 
 use crate::constants::STREAMING_SERVER_URL;
-use crate::deep_links::LibraryItemDeepLinks;
-use crate::deep_links::OpenPlayerLink;
+use crate::deep_links::{
+    ExternalPlayerId, ExternalPlayerRequest, LibraryItemDeepLinks, OpenPlayerLink,
+};
 use crate::types::library::LibraryItem;
 use crate::types::library::LibraryItemState;
 use crate::types::profile::Settings;
@@ -144,10 +145,13 @@ fn library_item_deep_links_state_video_id_no_time_offset_infuse_player() {
         lidl.external_player
             .expect("Should have external player")
             .open_player,
-            Some(OpenPlayerLink {
-                ios: Some(ios),
+        Some(OpenPlayerLink {
+            ios: Some(ExternalPlayerRequest {
+                player_id: ExternalPlayerId::Infuse,
                 ..
-            }) if ios.starts_with("infuse://")
+            }),
+            ..
+        })
     ));
     // with a Stream we should get a player link
     assert!(matches!(lidl.player, Some(player) if player.starts_with("stremio:///player")));
@@ -198,10 +202,13 @@ fn library_item_deep_links_state_video_id() {
         lidl.external_player
             .expect("Should have external player")
             .open_player,
-            Some(OpenPlayerLink {
-                ios: Some(ios),
+        Some(OpenPlayerLink {
+            ios: Some(ExternalPlayerRequest {
+                player_id: ExternalPlayerId::Infuse,
                 ..
-            }) if ios.starts_with("infuse://")
+            }),
+            ..
+        })
     ));
 }
 
@@ -254,10 +261,13 @@ fn library_item_deep_links_behavior_hints_default_video_id() {
         lidl.external_player
             .expect("Should have external player")
             .open_player,
-            Some(OpenPlayerLink {
-                ios: Some(ios),
+        Some(OpenPlayerLink {
+            ios: Some(ExternalPlayerRequest {
+                player_id: ExternalPlayerId::Infuse,
                 ..
-            }) if ios.starts_with("infuse://")
+            }),
+            ..
+        })
     ));
 }
 
@@ -310,10 +320,13 @@ fn library_item_deep_links_state_and_behavior_hints_default_video_id() {
         lidl.external_player
             .expect("Should have external player")
             .open_player,
-            Some(OpenPlayerLink {
-                ios: Some(ios),
+        Some(OpenPlayerLink {
+            ios: Some(ExternalPlayerRequest {
+                player_id: ExternalPlayerId::Infuse,
                 ..
-            }) if ios.starts_with("infuse://")
+            }),
+            ..
+        })
     ));
 }
 
@@ -366,9 +379,12 @@ fn library_item_deep_links_state_no_time_offset_and_behavior_hints_default_video
         lidl.external_player
             .expect("Should have external player")
             .open_player,
-            Some(OpenPlayerLink {
-                ios: Some(ios),
+        Some(OpenPlayerLink {
+            ios: Some(ExternalPlayerRequest {
+                player_id: ExternalPlayerId::Infuse,
                 ..
-            }) if ios.starts_with("infuse://")
+            }),
+            ..
+        })
     ));
 }


### PR DESCRIPTION
Replace player-specific deep links with typed `{ playerId, url, fileName? }` requests. Native clients remain responsible for validation and launch details.