### PR TITLE
Player: Preserve subtitle preference across loads

### DIFF
--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -25,7 +25,7 @@ use crate::types::api::{
     SuccessResponse,
 };
 use crate::types::library::{LibraryBucket, LibraryItem};
-use crate::types::player::{IntroData, IntroOutro};
+use crate::types::player::{IntroData, IntroOutro, SubtitlePreference};
 use crate::types::profile::{AuthKey, Profile};
 use crate::types::rating::{Rating, RatingSendRequest, RatingSendResponse};
 use crate::types::resource::{
@@ -105,6 +105,7 @@ pub struct Player {
     pub series_info: Option<SeriesInfo>,
     pub library_item: Option<LibraryItem>,
     pub stream_state: Option<StreamItemState>,
+    pub subtitle_preference: Option<SubtitlePreference>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub intro_outro: Option<IntroOutro>,
     #[serde(skip_serializing)]
@@ -369,6 +370,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                 let video_params_effects = eq_update(&mut self.video_params, None);
                 let meta_item_effects = eq_update(&mut self.meta_item, None);
                 let stream_state_effects = eq_update(&mut self.stream_state, None);
+                let subtitle_preference_effects = eq_update(&mut self.subtitle_preference, None);
                 let stream_effects = eq_update(&mut self.stream, None);
                 let subtitles_effects = eq_update(&mut self.subtitles, vec![]);
                 let next_video_effects = eq_update(&mut self.next_video, None);
@@ -394,6 +396,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     .join(stream_effects)
                     .join(meta_item_effects)
                     .join(stream_state_effects)
+                    .join(subtitle_preference_effects)
                     .join(subtitles_effects)
                     .join(next_video_effects)
                     .join(next_streams_effects)
@@ -441,6 +444,13 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                         .and_then(|selected| selected.meta_request.to_owned()),
                 }))
                 .unchanged()
+            }
+            Msg::Action(Action::Player(ActionPlayer::SubtitlePreferenceChanged { preference })) => {
+                if self.selected.is_some() {
+                    eq_update(&mut self.subtitle_preference, Some(*preference))
+                } else {
+                    Effects::none().unchanged()
+                }
             }
             Msg::Action(Action::Player(ActionPlayer::Seek {
                 time,

--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -19,6 +19,7 @@ use crate::{
         addon::Descriptor,
         api::AuthRequest,
         library::LibraryItemId,
+        player::SubtitlePreference,
         profile::{AuthKey, Password, Settings as ProfileSettings},
         rating::Rating,
         resource::{MetaItemId, MetaItemPreview, Video},
@@ -194,6 +195,10 @@ pub enum ActionPlayer {
     },
     StreamStateChanged {
         state: StreamItemState,
+    },
+    /// Updates the subtitle preference for the current Player session.
+    SubtitlePreferenceChanged {
+        preference: SubtitlePreference,
     },
     /// Seek performed by the user when using the seekbar or
     /// the shortcuts for seeking.

--- a/src/types/player.rs
+++ b/src/types/player.rs
@@ -1,4 +1,24 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Deserialize, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SubtitleSource {
+    Embedded,
+    External,
+}
+
+/// Subtitle preference for the current Player session.
+///
+/// It is preserved across Player loads and is intentionally independent from
+/// episode-specific subtitle tracks.
+#[derive(Clone, Copy, Deserialize, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubtitlePreference {
+    pub enabled: bool,
+    /// Preferred source, or `None` to keep the client's normal source ordering.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<SubtitleSource>,
+}
 
 #[derive(Clone, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/src/unit_tests/player/mod.rs
+++ b/src/unit_tests/player/mod.rs
@@ -1,5 +1,6 @@
 mod mark_video_as_watched;
 mod next_stream;
+mod subtitle_preference;
 
 use crate::{
     models::{

--- a/src/unit_tests/player/subtitle_preference.rs
+++ b/src/unit_tests/player/subtitle_preference.rs
@@ -1,0 +1,103 @@
+use crate::{
+    models::{
+        ctx::Ctx,
+        player::{Player, Selected},
+    },
+    runtime::{
+        msg::{Action, ActionLoad, ActionPlayer, Msg},
+        UpdateWithCtx,
+    },
+    types::{
+        player::{SubtitlePreference, SubtitleSource},
+        resource::{Stream, StreamBehaviorHints, StreamSource},
+    },
+    unit_tests::TestEnv,
+};
+
+fn selected(source_url: &str) -> Selected {
+    Selected {
+        stream: Stream {
+            source: StreamSource::Url {
+                url: source_url.parse().unwrap(),
+            },
+            name: None,
+            description: None,
+            thumbnail: None,
+            subtitles: vec![],
+            behavior_hints: StreamBehaviorHints::default(),
+        },
+        stream_request: None,
+        meta_request: None,
+        subtitles_path: None,
+    }
+}
+
+#[test]
+fn preference_is_scoped_to_player_session() {
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    let mut player = Player::default();
+    let ctx = Ctx::default();
+    let preference = SubtitlePreference {
+        enabled: false,
+        source: Some(SubtitleSource::External),
+    };
+    let preference_msg = Msg::Action(Action::Player(ActionPlayer::SubtitlePreferenceChanged {
+        preference,
+    }));
+
+    let effects = <Player as UpdateWithCtx<TestEnv>>::update(&mut player, &preference_msg, &ctx);
+    assert!(!effects.has_changed);
+    assert!(effects.is_empty());
+    assert_eq!(player.subtitle_preference, None);
+
+    <Player as UpdateWithCtx<TestEnv>>::update(
+        &mut player,
+        &Msg::Action(Action::Load(ActionLoad::Player(Box::new(selected(
+            "https://source_url/1",
+        ))))),
+        &ctx,
+    );
+    let effects = <Player as UpdateWithCtx<TestEnv>>::update(&mut player, &preference_msg, &ctx);
+    assert!(effects.has_changed);
+    assert!(effects.is_empty());
+    assert_eq!(player.subtitle_preference, Some(preference));
+
+    <Player as UpdateWithCtx<TestEnv>>::update(
+        &mut player,
+        &Msg::Action(Action::Load(ActionLoad::Player(Box::new(selected(
+            "https://source_url/2",
+        ))))),
+        &ctx,
+    );
+    assert_eq!(player.subtitle_preference, Some(preference));
+
+    <Player as UpdateWithCtx<TestEnv>>::update(&mut player, &Msg::Action(Action::Unload), &ctx);
+    assert_eq!(player.subtitle_preference, None);
+}
+
+#[test]
+fn action_deserializes() {
+    let action = serde_json::from_value::<Action>(serde_json::json!({
+        "action": "Player",
+        "args": {
+            "action": "SubtitlePreferenceChanged",
+            "args": {
+                "preference": {
+                    "enabled": true,
+                    "source": "embedded"
+                }
+            }
+        }
+    }))
+    .expect("Should deserialize subtitle preference action");
+
+    assert!(matches!(
+        action,
+        Action::Player(ActionPlayer::SubtitlePreferenceChanged {
+            preference: SubtitlePreference {
+                enabled: true,
+                source: Some(SubtitleSource::Embedded),
+            }
+        })
+    ));
+}

--- a/stremio-core-web/src/model/serialize_player.rs
+++ b/stremio-core-web/src/model/serialize_player.rs
@@ -11,6 +11,7 @@ use stremio_core::models::player::Player;
 use stremio_core::models::streaming_server::StreamingServer;
 use stremio_core::types::{
     addon::{ResourcePath, ResourceRequest},
+    player::SubtitlePreference,
     streams::StreamItemState,
 };
 
@@ -113,6 +114,7 @@ mod model {
         pub series_info: Option<&'a stremio_core::types::resource::SeriesInfo>,
         pub library_item: Option<LibraryItem<'a>>,
         pub stream_state: Option<&'a StreamItemState>,
+        pub subtitle_preference: Option<&'a SubtitlePreference>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub intro_outro: Option<&'a stremio_core::types::player::IntroOutro>,
         pub title: Option<String>,
@@ -328,6 +330,7 @@ pub fn serialize_player<E: stremio_core::runtime::Env + 'static>(
                 },
             }),
         stream_state: player.stream_state.as_ref(),
+        subtitle_preference: player.subtitle_preference.as_ref(),
         intro_outro: player.intro_outro.as_ref(),
         title: player.selected.as_ref().and_then(|selected| {
             player


### PR DESCRIPTION
Adds a shared player-session subtitle preference for clients.