### PR TITLE
Player: Preserve subtitle language across loads

### DIFF
--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -447,7 +447,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
             }
             Msg::Action(Action::Player(ActionPlayer::SubtitlePreferenceChanged { preference })) => {
                 if self.selected.is_some() {
-                    eq_update(&mut self.subtitle_preference, Some(*preference))
+                    eq_update(&mut self.subtitle_preference, Some(preference.to_owned()))
                 } else {
                     Effects::none().unchanged()
                 }

--- a/src/types/player.rs
+++ b/src/types/player.rs
@@ -11,13 +11,16 @@ pub enum SubtitleSource {
 ///
 /// It is preserved across Player loads and is intentionally independent from
 /// episode-specific subtitle tracks.
-#[derive(Clone, Copy, Deserialize, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Deserialize, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubtitlePreference {
     pub enabled: bool,
     /// Preferred source, or `None` to keep the client's normal source ordering.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<SubtitleSource>,
+    /// Preferred normalized language code, or `None` when it is unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
 }
 
 #[derive(Clone, Serialize, Debug, PartialEq, Eq)]

--- a/src/unit_tests/player/subtitle_preference.rs
+++ b/src/unit_tests/player/subtitle_preference.rs
@@ -40,9 +40,10 @@ fn preference_is_scoped_to_player_session() {
     let preference = SubtitlePreference {
         enabled: false,
         source: Some(SubtitleSource::External),
+        language: Some("bul".to_owned()),
     };
     let preference_msg = Msg::Action(Action::Player(ActionPlayer::SubtitlePreferenceChanged {
-        preference,
+        preference: preference.to_owned(),
     }));
 
     let effects = <Player as UpdateWithCtx<TestEnv>>::update(&mut player, &preference_msg, &ctx);
@@ -60,7 +61,7 @@ fn preference_is_scoped_to_player_session() {
     let effects = <Player as UpdateWithCtx<TestEnv>>::update(&mut player, &preference_msg, &ctx);
     assert!(effects.has_changed);
     assert!(effects.is_empty());
-    assert_eq!(player.subtitle_preference, Some(preference));
+    assert_eq!(player.subtitle_preference, Some(preference.to_owned()));
 
     <Player as UpdateWithCtx<TestEnv>>::update(
         &mut player,
@@ -84,7 +85,8 @@ fn action_deserializes() {
             "args": {
                 "preference": {
                     "enabled": true,
-                    "source": "embedded"
+                    "source": "embedded",
+                    "language": "bul"
                 }
             }
         }
@@ -97,6 +99,35 @@ fn action_deserializes() {
             preference: SubtitlePreference {
                 enabled: true,
                 source: Some(SubtitleSource::Embedded),
+                language: Some(language),
+            }
+        }) if language == "bul"
+    ));
+}
+
+#[test]
+fn action_without_language_deserializes() {
+    let action = serde_json::from_value::<Action>(serde_json::json!({
+        "action": "Player",
+        "args": {
+            "action": "SubtitlePreferenceChanged",
+            "args": {
+                "preference": {
+                    "enabled": false,
+                    "source": "external"
+                }
+            }
+        }
+    }))
+    .expect("Should deserialize subtitle preference action without language");
+
+    assert!(matches!(
+        action,
+        Action::Player(ActionPlayer::SubtitlePreferenceChanged {
+            preference: SubtitlePreference {
+                enabled: false,
+                source: Some(SubtitleSource::External),
+                language: None,
             }
         })
     ));


### PR DESCRIPTION
Stacked on #1020.

Adds language to the player-session subtitle preference.