### PR TITLE
feat(streaming-server): add StopOnDevice and SetDeviceSubtitles actions

### DIFF
--- a/src/models/streaming_server.rs
+++ b/src/models/streaming_server.rs
@@ -11,6 +11,7 @@ use crate::models::common::{eq_update, Loadable};
 use crate::models::ctx::{Ctx, CtxError};
 use crate::runtime::msg::{
     Action, ActionStreamingServer, CreateTorrentArgs, Event, Internal, Msg, PlayOnDeviceArgs,
+    SetDeviceSubtitlesArgs, StopOnDeviceArgs,
 };
 use crate::runtime::{Effect, EffectFuture, Effects, Env, EnvError, EnvFutureExt, UpdateWithCtx};
 use crate::types::addon::ResourcePath;
@@ -240,6 +241,31 @@ impl<E: Env + 'static> UpdateWithCtx<E> for StreamingServer {
                     _ => Effects::none().unchanged(),
                 }
             }
+            Msg::Action(Action::StreamingServer(ActionStreamingServer::StopOnDevice(args))) => {
+                // Not gated on the device still being in `playback_devices`: stopping must work
+                // even when the list has not been refreshed since the playback was started.
+                Effects::one(stop_on_device::<E>(&self.selected.transport_url, args)).unchanged()
+            }
+            Msg::Action(Action::StreamingServer(ActionStreamingServer::SetDeviceSubtitles(
+                args,
+            ))) => match &mut self.playback_devices {
+                Loadable::Ready(playback_devices) => {
+                    let device_exists = playback_devices
+                        .iter()
+                        .any(|device| device.id == args.device);
+                    match device_exists {
+                        true => {
+                            Effects::one(set_device_subtitles::<E>(
+                                &self.selected.transport_url,
+                                args,
+                            ))
+                            .unchanged()
+                        }
+                        _ => Effects::none().unchanged(),
+                    }
+                }
+                _ => Effects::none().unchanged(),
+            },
             Msg::Internal(Internal::ProfileChanged)
                 if self.selected.transport_url != ctx.profile.settings.streaming_server_url =>
             {
@@ -409,6 +435,20 @@ impl<E: Env + 'static> UpdateWithCtx<E> for StreamingServer {
                     }
                     Err(_) => Effects::none().unchanged(),
                 }
+            }
+            Msg::Internal(Internal::StreamingServerStopOnDeviceResult(device, result)) => {
+                match result {
+                    Ok(_) => {
+                        Effects::one(Effect::Msg(Box::new(Msg::Event(Event::StoppedOnDevice {
+                            device: device.to_owned(),
+                        }))))
+                        .unchanged()
+                    }
+                    Err(_) => Effects::none().unchanged(),
+                }
+            }
+            Msg::Internal(Internal::StreamingServerSetDeviceSubtitlesResult(_, _)) => {
+                Effects::none().unchanged()
             }
             Msg::Internal(Internal::StreamingServerGetHTTPSResult(url, result))
                 if self.selected.transport_url == *url =>
@@ -707,6 +747,60 @@ fn get_torrent_statistics<E: Env + 'static>(url: &Url, request: &StatisticsReque
         fetch_fut
             .map(enclose!((url, request) move |result|
                 Msg::Internal(Internal::StreamingServerStatisticsResult((url, request), result))
+            ))
+            .boxed_env(),
+    )
+    .into()
+}
+
+fn stop_on_device<E: Env + 'static>(url: &Url, args: &StopOnDeviceArgs) -> Effect {
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Body {
+        // The stremio-cast protocol stops the playback when `source` is set to null.
+        source: Option<String>,
+    }
+    let device = args.device.clone();
+    let endpoint = url
+        .join(&format!("casting/{device}/player"))
+        .expect("url builder failed");
+    let request = Request::post(endpoint.as_str())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body { source: None })
+        .expect("request builder failed");
+    EffectFuture::Concurrent(
+        E::fetch::<_, serde_json::Value>(request)
+            .map_ok(|_| ())
+            .map(enclose!(() move |result|
+                Msg::Internal(Internal::StreamingServerStopOnDeviceResult(device, result))
+            ))
+            .boxed_env(),
+    )
+    .into()
+}
+
+fn set_device_subtitles<E: Env + 'static>(url: &Url, args: &SetDeviceSubtitlesArgs) -> Effect {
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Body {
+        subtitles_src: Option<String>,
+    }
+    let device = args.device.clone();
+    let endpoint = url
+        .join(&format!("casting/{device}/player"))
+        .expect("url builder failed");
+    let body = Body {
+        subtitles_src: args.subtitles_src.to_owned(),
+    };
+    let request = Request::post(endpoint.as_str())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(body)
+        .expect("request builder failed");
+    EffectFuture::Concurrent(
+        E::fetch::<_, serde_json::Value>(request)
+            .map_ok(|_| ())
+            .map(enclose!(() move |result|
+                Msg::Internal(Internal::StreamingServerSetDeviceSubtitlesResult(device, result))
             ))
             .boxed_env(),
     )

--- a/src/runtime/msg/action.rs
+++ b/src/runtime/msg/action.rs
@@ -175,6 +175,19 @@ pub struct PlayOnDeviceArgs {
 }
 
 #[derive(Clone, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct StopOnDeviceArgs {
+    pub device: String,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SetDeviceSubtitlesArgs {
+    pub device: String,
+    pub subtitles_src: Option<String>,
+}
+
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "action", content = "args")]
 pub enum ActionStreamingServer {
     Reload,
@@ -183,6 +196,8 @@ pub enum ActionStreamingServer {
     CreateTorrent(CreateTorrentArgs),
     GetStatistics(StreamingServerStatisticsRequest),
     PlayOnDevice(PlayOnDeviceArgs),
+    StopOnDevice(StopOnDeviceArgs),
+    SetDeviceSubtitles(SetDeviceSubtitlesArgs),
 }
 
 #[derive(Clone, Deserialize, Debug)]

--- a/src/runtime/msg/event.rs
+++ b/src/runtime/msg/event.rs
@@ -149,6 +149,9 @@ pub enum Event {
     PlayingOnDevice {
         device: String,
     },
+    StoppedOnDevice {
+        device: String,
+    },
     StreamingServerUrlsBucketChanged {
         uid: UID,
     },

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -131,6 +131,10 @@ pub enum Internal {
     StreamingServerCreateTorrentResult(InfoHash, Result<(), EnvError>),
     /// Result for playing on device.
     StreamingServerPlayOnDeviceResult(String, Result<(), EnvError>),
+    /// Result for stopping the playback on device.
+    StreamingServerStopOnDeviceResult(String, Result<(), EnvError>),
+    /// Result for setting the subtitles of the player on device.
+    StreamingServerSetDeviceSubtitlesResult(String, Result<(), EnvError>),
     // Result for get https endpoint request
     StreamingServerGetHTTPSResult(Url, Result<GetHTTPSResponse, EnvError>),
     /// Result for streaming server statistics.


### PR DESCRIPTION
### Problem

`ActionStreamingServer::PlayOnDevice` starts a casting session, but nothing can stop it or set the subtitles of the remote player. The UI therefore has no counterpart for either:

- leaving the player keeps the device playing, with no way to stop it from the app — Stremio/stremio-bugs#2733
- the selected subtitles track never reaches the device, so subtitles render locally only — Stremio/stremio-bugs#2732

Stremio 4.4 did both, through the same endpoint.

### Changes

The streaming server implements the stremio-cast protocol on `/casting/{device}/player`: a `POST` sets player properties, `source: null` stops the playback, `subtitlesSrc` sets the subtitles URL.

- `ActionStreamingServer::StopOnDevice { device }` → `POST {"source": null}`
- `ActionStreamingServer::SetDeviceSubtitles { device, subtitlesSrc }` → `POST {"subtitlesSrc": ...}`
- `Internal::StreamingServerStopOnDeviceResult` / `StreamingServerSetDeviceSubtitlesResult`
- `Event::StoppedOnDevice { device }`, mirroring `PlayingOnDevice`

`SetDeviceSubtitles` is gated on the device being present in `playback_devices`, like `PlayOnDevice`. `StopOnDevice` deliberately is not: a session must be stoppable even if the device list has not been refreshed since playback started.

Verified against a running streaming server — `GET /casting/{device}/player` on a live session returns `subtitlesSrc`, `subtitlesDelay`, `subtitlesSize` alongside `source`, and devices advertise `"playerUIRoles":[...,"subtitles",...]`.

### Consumer

https://github.com/Stremio/stremio-web/pull/1376 uses these actions (it previously called the endpoint from the web layer, which was correctly flagged in review).

### Note

I have no Rust toolchain on this machine, so this has not been compiled locally — please let CI weigh in; I'll fix anything it flags. `subtitlesDelay` / `subtitlesSize` are left out on purpose: the endpoint accepts them, but their scale differs from the in-app settings and I did not want to guess the mapping.
