### PR TITLE
feat: option to enable/disable add-ons without uninstalling

### DIFF
--- a/src/models/catalog_with_filters.rs
+++ b/src/models/catalog_with_filters.rs
@@ -305,6 +305,7 @@ fn selectable_update<T: CatalogResourceAdapter>(
     let selectable_catalogs = profile
         .addons
         .iter()
+        .filter(|addon| !addon.flags.disabled)
         .flat_map(|addon| {
             T::catalogs(&addon.manifest)
                 .iter()

--- a/src/models/catalogs_with_extra.rs
+++ b/src/models/catalogs_with_extra.rs
@@ -77,6 +77,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for CatalogsWithExtra {
                         .profile
                         .addons
                         .iter()
+                        .filter(|addon| !addon.flags.disabled)
                         .find(|addon| addon.transport_url == request.base)
                         .and_then(|addon| {
                             addon.manifest.catalogs.iter().find(|manifest_catalog| {

--- a/src/types/addon/descriptor.rs
+++ b/src/types/addon/descriptor.rs
@@ -35,4 +35,6 @@ pub struct DescriptorFlags {
     pub official: bool,
     #[serde(default)]
     pub protected: bool,
+    #[serde(default)]
+    pub disabled: bool,
 }

--- a/src/types/addon/request.rs
+++ b/src/types/addon/request.rs
@@ -169,6 +169,7 @@ impl AggrRequest<'_> {
         match &self {
             AggrRequest::AllCatalogs { extra, r#type } => addons
                 .iter()
+                .filter(|addon| !addon.flags.disabled)
                 .flat_map(|addon| {
                     addon
                         .manifest
@@ -215,6 +216,7 @@ impl AggrRequest<'_> {
                         } => {
                             addons
                                 .iter()
+                                .filter(|addon| !addon.flags.disabled)
                                 .flat_map(|addon| {
                                     addon
                                         .manifest
@@ -358,6 +360,7 @@ impl AggrRequest<'_> {
             }
             AggrRequest::AllOfResource(path) => addons
                 .iter()
+                .filter(|addon| !addon.flags.disabled)
                 .filter(|addon| addon.manifest.is_resource_supported(path))
                 .map(|addon| {
                     (


### PR DESCRIPTION
Resolves #1028

This PR adds a `disabled` boolean flag to `DescriptorFlags`. When an addon is marked as disabled, it is filtered out from `AggrRequest::plan` and selectable catalogs in `CatalogWithFilters`, meaning it will not be queried for streams, catalogs, subtitles, etc., essentially acting as disabled.

The addons will still show up in the `InstalledAddonsWithFilters` model, allowing users (via front-end UI) to re-enable them by updating their `disabled` flag via the existing `InstallAddon` action.