### PR TITLE
Skip unreleased next episodes

### DIFF
--- a/src/models/meta_details.rs
+++ b/src/models/meta_details.rs
@@ -154,7 +154,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for MetaDetails {
                             .meta_items
                             .iter()
                             .find_map(|item| item.content.as_ref().and_then(|c| c.ready()))
-                            .and_then(|meta_item| meta_item.next_video(&video.id))
+                            .and_then(|meta_item| meta_item.next_video(&video.id, &E::now()))
                             .map(|video| video.id.to_owned());
                         if let Some(next_video_id) = next_video_id {
                             library_item.advance_to_video(&next_video_id);
@@ -452,7 +452,7 @@ fn external_player_progress_update<E: Env + 'static>(
             let next_video_id = meta_items
                 .iter()
                 .find_map(|meta_item| match &meta_item.content {
-                    Some(Loadable::Ready(meta_item)) => meta_item.next_video(video_id),
+                    Some(Loadable::Ready(meta_item)) => meta_item.next_video(video_id, &E::now()),
                     _ => None,
                 })
                 .map(|video| video.id.to_owned());

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -213,7 +213,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                     self.stream.as_ref(),
                     &ctx.profile.addons,
                 );
-                let next_video_effects = next_video_update(
+                let next_video_effects = next_video_update::<E>(
                     &mut self.next_video,
                     &self.next_stream,
                     &self.selected,
@@ -867,7 +867,7 @@ impl<E: Env + 'static> UpdateWithCtx<E> for Player {
                 let next_stream_effects =
                     next_stream_update(&mut self.next_stream, &self.next_streams, &self.selected);
 
-                let next_video_effects = next_video_update(
+                let next_video_effects = next_video_update::<E>(
                     &mut self.next_video,
                     &self.next_stream,
                     &self.selected,
@@ -1039,7 +1039,7 @@ fn stream_state_update(
     eq_update(state, next_state)
 }
 
-fn next_video_update(
+fn next_video_update<E: Env>(
     video: &mut Option<Video>,
     stream: &Option<Stream>,
     selected: &Option<Selected>,
@@ -1059,7 +1059,7 @@ fn next_video_update(
                 content: Some(Loadable::Ready(meta_item)),
                 ..
             }),
-        ) => meta_item.next_video(video_id).map(|next_video| {
+        ) => meta_item.next_video(video_id, &E::now()).map(|next_video| {
             let mut next_video = next_video.clone();
             if let Some(stream) = stream {
                 next_video.streams = vec![stream.clone()];

--- a/src/types/resource/meta_item.rs
+++ b/src/types/resource/meta_item.rs
@@ -268,8 +268,9 @@ impl MetaItem {
         }
     }
 
-    /// Returns the next video after the given one, without crossing into season 0 specials
-    pub fn next_video(&self, video_id: &str) -> Option<&Video> {
+    /// Returns the next released video after the given one, without crossing into season 0 specials.
+    /// Videos without a release date are treated as released.
+    pub fn next_video(&self, video_id: &str, now: &DateTime<Utc>) -> Option<&Video> {
         self.videos
             .iter()
             .find_position(|v| v.id == video_id)
@@ -285,7 +286,11 @@ impl MetaItem {
                     .as_ref()
                     .map(|s| s.season)
                     .unwrap_or_default();
-                next_season != 0 || cur_season == next_season
+                let released = match next.released.as_ref() {
+                    Some(released) => released <= now,
+                    None => true,
+                };
+                (next_season != 0 || cur_season == next_season) && released
             })
             .map(|(_, next)| next)
     }
@@ -433,6 +438,8 @@ pub struct MetaItemBehaviorHints {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Duration;
+
     use super::*;
 
     fn create_video(id: &str, season: u32, episode: u32) -> Video {
@@ -445,6 +452,7 @@ mod tests {
 
     #[test]
     fn next_video() {
+        let now = Utc::now();
         let meta_item = MetaItem {
             preview: Default::default(),
             videos: vec![
@@ -452,35 +460,73 @@ mod tests {
                 create_video("s0e2", 0, 2),
                 create_video("s1e1", 1, 1),
                 create_video("s1e2", 1, 2),
+                create_video("s2e1", 2, 1),
                 create_video("s0e3", 0, 3),
             ],
         };
         assert_eq!(
-            meta_item.next_video("s0e1").map(|video| video.id.as_str()),
+            meta_item
+                .next_video("s0e1", &now)
+                .map(|video| video.id.as_str()),
             Some("s0e2")
         );
         assert_eq!(
-            meta_item.next_video("s0e2").map(|video| video.id.as_str()),
+            meta_item
+                .next_video("s0e2", &now)
+                .map(|video| video.id.as_str()),
             Some("s1e1")
         );
         assert_eq!(
-            meta_item.next_video("s1e1").map(|video| video.id.as_str()),
+            meta_item
+                .next_video("s1e1", &now)
+                .map(|video| video.id.as_str()),
             Some("s1e2")
         );
         assert_eq!(
-            meta_item.next_video("s1e2").map(|video| video.id.as_str()),
+            meta_item
+                .next_video("s1e2", &now)
+                .map(|video| video.id.as_str()),
+            Some("s2e1")
+        );
+        assert_eq!(
+            meta_item
+                .next_video("s2e1", &now)
+                .map(|video| video.id.as_str()),
             None,
             "should not cross into season 0 specials"
         );
         assert_eq!(
-            meta_item.next_video("s0e3").map(|video| video.id.as_str()),
+            meta_item
+                .next_video("s0e3", &now)
+                .map(|video| video.id.as_str()),
             None
         );
         assert_eq!(
             meta_item
-                .next_video("missing")
+                .next_video("missing", &now)
                 .map(|video| video.id.as_str()),
             None
+        );
+    }
+
+    #[test]
+    fn next_video_excludes_unreleased_video() {
+        let now = Utc::now();
+        let mut next_video = create_video("s1e2", 1, 2);
+        next_video.released = Some(now + Duration::days(1));
+        let mut meta_item = MetaItem {
+            preview: Default::default(),
+            videos: vec![create_video("s1e1", 1, 1), next_video],
+        };
+
+        assert_eq!(meta_item.next_video("s1e1", &now), None);
+
+        meta_item.videos[1].released = Some(now);
+        assert_eq!(
+            meta_item
+                .next_video("s1e1", &now)
+                .map(|video| video.id.as_str()),
+            Some("s1e2")
         );
     }
 }

--- a/src/unit_tests/meta_details/mark_video_as_watched.rs
+++ b/src/unit_tests/meta_details/mark_video_as_watched.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     unit_tests::{default_fetch_handler, Request, TestEnv, FETCH_HANDLER},
 };
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use futures::future;
 use std::any::Any;
 use stremio_derive::Model;
@@ -51,6 +51,27 @@ fn fetch_handler(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
                         ..Default::default()
                     },
                     videos: vec![create_video(1, 1), create_video(1, 2)],
+                },
+            }) as Box<dyn Any + Send>)
+            .boxed_env()
+        }
+        _ => default_fetch_handler(request),
+    }
+}
+
+fn fetch_handler_unreleased_next(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+    match request {
+        Request { url, .. } if url == "https://v3-cinemeta.strem.io/meta/series/tt123456.json" => {
+            let mut next_video = create_video(1, 2);
+            next_video.released = Some(Utc::now() + Duration::days(1));
+            future::ok(Box::new(ResourceResponse::Meta {
+                meta: MetaItem {
+                    preview: MetaItemPreview {
+                        id: "tt123456".to_owned(),
+                        r#type: "series".to_owned(),
+                        ..Default::default()
+                    },
+                    videos: vec![create_video(1, 1), next_video],
                 },
             }) as Box<dyn Any + Send>)
             .boxed_env()
@@ -218,6 +239,38 @@ fn mark_video_as_watched_advances_video_id() {
         PREVIOUS_OVERALL_TIME_WATCHED + PREVIOUS_TIME_WATCHED,
         "previous episode time_watched should be folded into overall_time_watched",
     );
+}
+
+#[test]
+fn mark_video_as_watched_does_not_advance_to_unreleased_video() {
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler_unreleased_next);
+
+    run_with_library_item(create_library_item("tt123456:1:1"), |runtime| {
+        load_selected_video(&runtime, "tt123456:1:1");
+
+        TestEnv::run(|| {
+            runtime.dispatch(RuntimeAction {
+                field: None,
+                action: Action::MetaDetails(ActionMetaDetails::MarkVideoAsWatched(
+                    create_video(1, 1),
+                    true,
+                )),
+            });
+        });
+
+        let model = runtime.model().unwrap();
+        let library_item = model.ctx.library.items.get("tt123456").unwrap();
+        assert_eq!(
+            library_item.state.video_id,
+            Some("tt123456:1:1".to_owned()),
+            "video_id should remain on the current episode when the next one is unreleased",
+        );
+        assert_eq!(
+            library_item.state.time_offset, 0,
+            "unreleased episodes should not keep the item in Continue Watching",
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
prev the CW advanced to next episode even if the next episode was unreleased which is unreliable because you are getting redirected to an empty meta details without any streams. now it will not advance and correctly show a new episode notification only when new episode releases and can be continued from it.