### PR TITLE
Restore branch prebuild publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
   # this will still create a package for testing!
   push:
     branches:
-      - development
+      - '**'
     tags-ignore:
       - '**'
   pull_request:
@@ -23,6 +23,9 @@ concurrency:
 
 jobs:
   build-core:
+    # Same-repository branches are checked on push so they can publish a testing package.
+    # Pull request runs are only needed for forks, whose pushes do not run here.
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
     name: "stremio-core-*: Lint, test and build"
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pr-prebuild-comment.yml
+++ b/.github/workflows/pr-prebuild-comment.yml
@@ -1,16 +1,14 @@
 name: PR prebuild comment
 
-# Fires once when a PR is opened against `development`. Posts a single
-# comment with paste-ready `package.json` overrides pointing at the
+# Fires once when a same-repository PR is opened against `development`. Posts
+# a single comment with paste-ready `package.json` overrides pointing at the
 # stremio-core-web prebuild that the `Build` workflow publishes to gh-pages
 # for the PR's source branch. Does NOT run again on subsequent pushes.
 #
-# Uses `pull_request_target` so the comment also works for PRs from forks
-# (the default `pull_request` event hands fork runs a read-only token, which
-# can't post comments). This is safe here because the workflow never executes
-# any code from the PR — `actions/checkout` checks out the BASE branch, and
-# the only PR-derived value used is `pull_request.head.ref`, a metadata
-# string that goes into a URL/comment body, never into a shell or eval.
+# Fork PRs do not get a prebuild because their pushes do not run in this
+# repository. Uses `pull_request_target` to post from the base workflow without
+# executing any code from the PR: `actions/checkout` checks out the BASE branch,
+# and `pull_request.head.ref` is only inserted into the comment body.
 
 on:
   pull_request_target:
@@ -24,6 +22,7 @@ permissions:
 
 jobs:
   comment:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -46,7 +45,7 @@ jobs:
             const body = [
               '### stremio-core-web prebuild',
               '',
-              `Prebuild artifact published by the \`Build\` workflow for branch \`${branch}\`.`,
+              `Prebuild artifact published by the \`Build\` workflow after a successful push to branch \`${branch}\`.`,
               '',
               'Paste one of these into `stremio-web`\'s `package.json` and run `pnpm install` to wire this prebuild into a corresponding `stremio-web` PR:',
               '',


### PR DESCRIPTION
Restore Core Web prebuild publication for branch pushes without running duplicate jobs for same-repository PR events. Fork PRs still run full CI and no longer receive unusable package links.