### PR TITLE
Addon details: Don't panic on invalid stremio transport URL

### DIFF
--- a/src/models/addon_details.rs
+++ b/src/models/addon_details.rs
@@ -23,7 +23,7 @@ where
     if url.scheme() == "stremio" {
         let replaced_url = url.as_str().replacen("stremio://", "https://", 1);
 
-        Ok(replaced_url.parse().expect("Should be able to parse URL"))
+        replaced_url.parse().map_err(serde::de::Error::custom)
     } else {
         Ok(url)
     }
@@ -115,5 +115,13 @@ mod test {
 
             assert_eq!(expected, selected.transport_url.as_str());
         }
+    }
+
+    #[test]
+    fn test_deserialization_of_select_with_hostless_stremio_url() {
+        let selected_json = json!({ "transportUrl": "stremio://" });
+
+        from_value::<Selected>(selected_json)
+            .expect_err("Should not deserialize a stremio URL without a host");
     }
 }


### PR DESCRIPTION
`stremio://` transport URLs are rewritten to `https://` before parsing and the result went through `.expect()`. A URL with no host, like `stremio://` or `stremio:///manifest.json`, rewrites to something that cannot be parsed, so the deserializer panics instead of failing.

The value comes straight from `ActionLoad::AddonDetails`, so on web a crafted `#/addons?addon=stremio://` link panics the wasm worker.

Returns a deserialization error instead, and adds the hostless cases to the existing test.
