### PR TITLE
feat(subtitles): keep add-on specific subtitle properties

### DIFF
--- a/src/types/resource/subtitles.rs
+++ b/src/types/resource/subtitles.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
+
 #[cfg(test)]
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+/// See <https://github.com/Stremio/stremio-addon-sdk/blob/master/docs/api/responses/subtitles.md> for documentation
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Derivative))]
 #[cfg_attr(test, derivative(Default))]
@@ -18,4 +21,20 @@ pub struct Subtitles {
     pub label: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fonts: Vec<Url>,
+    /// Any other properties the add-on sent along with the subtitle.
+    ///
+    /// The protocol only specifies `id`, `url` and `lang`, but add-ons
+    /// commonly attach extra properties that a client can make good use of,
+    /// e.g. the OpenSubtitles v3 add-on sends `subtitleFileName`,
+    /// `movieReleaseName`, `releaseGroup` and `fpsMilli` on every subtitle.
+    /// Instead of blessing one add-on's property names, we keep whatever was
+    /// sent, so that it reaches the UI rather than being silently dropped.
+    ///
+    /// Same approach as [`StreamBehaviorHints::other`] and
+    /// [`MetaItemBehaviorHints::other`].
+    ///
+    /// [`StreamBehaviorHints::other`]: crate::types::resource::StreamBehaviorHints::other
+    /// [`MetaItemBehaviorHints::other`]: crate::types::resource::MetaItemBehaviorHints::other
+    #[serde(flatten)]
+    pub other: HashMap<String, serde_json::Value>,
 }

--- a/src/unit_tests/serde/default_tokens_ext.rs
+++ b/src/unit_tests/serde/default_tokens_ext.rs
@@ -54,17 +54,14 @@ impl DefaultTokens for LibraryItemState {
 impl DefaultTokens for Subtitles {
     fn default_tokens() -> Vec<Token> {
         vec![
-            Token::Struct {
-                name: "Subtitles",
-                len: 3,
-            },
+            Token::Map { len: None },
             Token::Str("id"),
             Token::Str(""),
             Token::Str("lang"),
             Token::Str(""),
             Token::Str("url"),
             Token::Str("protocol://host"),
-            Token::StructEnd,
+            Token::MapEnd,
         ]
     }
 }

--- a/src/unit_tests/serde/subtitles.rs
+++ b/src/unit_tests/serde/subtitles.rs
@@ -1,3 +1,4 @@
+use crate::types::addon::ResourceResponse;
 use crate::types::resource::Subtitles;
 use serde_test::{assert_tokens, Token};
 use url::Url;
@@ -11,19 +12,17 @@ fn subtitles() {
             url: Url::parse("https://url").unwrap(),
             label: None,
             fonts: vec![],
+            other: Default::default(),
         },
         &[
-            Token::Struct {
-                name: "Subtitles",
-                len: 3,
-            },
+            Token::Map { len: None },
             Token::Str("id"),
             Token::Str("id"),
             Token::Str("lang"),
             Token::Str("lang"),
             Token::Str("url"),
             Token::Str("https://url/"),
-            Token::StructEnd,
+            Token::MapEnd,
         ],
     );
 }
@@ -37,12 +36,10 @@ fn subtitles_with_label() {
             url: Url::parse("https://url").unwrap(),
             label: Some("eng #1 [opensubtitles] 1080p.BluRay".to_owned()),
             fonts: vec![],
+            other: Default::default(),
         },
         &[
-            Token::Struct {
-                name: "Subtitles",
-                len: 4,
-            },
+            Token::Map { len: None },
             Token::Str("id"),
             Token::Str("id"),
             Token::Str("lang"),
@@ -52,7 +49,7 @@ fn subtitles_with_label() {
             Token::Str("label"),
             Token::Some,
             Token::Str("eng #1 [opensubtitles] 1080p.BluRay"),
-            Token::StructEnd,
+            Token::MapEnd,
         ],
     );
 }
@@ -69,12 +66,10 @@ fn subtitles_with_fonts() {
                 Url::parse("https://example.com/font.ttf").unwrap(),
                 Url::parse("https://example.com/font.otf").unwrap(),
             ],
+            other: Default::default(),
         },
         &[
-            Token::Struct {
-                name: "Subtitles",
-                len: 4,
-            },
+            Token::Map { len: None },
             Token::Str("id"),
             Token::Str("id"),
             Token::Str("lang"),
@@ -86,7 +81,107 @@ fn subtitles_with_fonts() {
             Token::Str("https://example.com/font.ttf"),
             Token::Str("https://example.com/font.otf"),
             Token::SeqEnd,
-            Token::StructEnd,
+            Token::MapEnd,
         ],
+    );
+}
+
+/// The add-on specific properties, e.g. the ones the OpenSubtitles v3 add-on
+/// sends, must survive deserialization of a subtitles resource response.
+#[test]
+fn subtitles_response_keeps_add_on_specific_properties() {
+    let response = serde_json::json!({
+        "subtitles": [
+            {
+                "id": "1",
+                "url": "https://opensubtitles.example/1.srt",
+                "lang": "eng",
+                "SubEncoding": "CP1252",
+                "subtitleFileName": "Movie.2009.1080p.BluRay.x264-GROUP.srt",
+                "movieReleaseName": "Movie.2009.1080p.BluRay.x264-GROUP",
+                "releaseGroup": "GROUP",
+                "fpsMilli": 23976
+            }
+        ]
+    });
+
+    let subtitles = match serde_json::from_value::<ResourceResponse>(response).unwrap() {
+        ResourceResponse::Subtitles { subtitles } => subtitles,
+        _ => panic!("Whoops, wrong variant!"),
+    };
+    let subtitle = &subtitles[0];
+
+    assert_eq!("1", subtitle.id);
+    assert_eq!("eng", subtitle.lang);
+    assert_eq!(
+        Url::parse("https://opensubtitles.example/1.srt").unwrap(),
+        subtitle.url
+    );
+    assert_eq!(None, subtitle.label);
+    assert!(subtitle.fonts.is_empty());
+    assert_eq!(
+        Some(&serde_json::json!("Movie.2009.1080p.BluRay.x264-GROUP.srt")),
+        subtitle.other.get("subtitleFileName")
+    );
+    assert_eq!(
+        Some(&serde_json::json!("Movie.2009.1080p.BluRay.x264-GROUP")),
+        subtitle.other.get("movieReleaseName")
+    );
+    assert_eq!(
+        Some(&serde_json::json!("GROUP")),
+        subtitle.other.get("releaseGroup")
+    );
+    assert_eq!(
+        Some(&serde_json::json!(23976)),
+        subtitle.other.get("fpsMilli")
+    );
+    assert_eq!(
+        Some(&serde_json::json!("CP1252")),
+        subtitle.other.get("SubEncoding")
+    );
+    assert_eq!(5, subtitle.other.len());
+}
+
+/// A subtitle without any add-on specific properties deserializes exactly as
+/// it did before and serializes without any additional keys.
+#[test]
+fn subtitles_without_add_on_specific_properties() {
+    let subtitle = serde_json::from_value::<Subtitles>(serde_json::json!({
+        "id": "1",
+        "url": "https://opensubtitles.example/1.srt",
+        "lang": "eng"
+    }))
+    .unwrap();
+
+    assert!(subtitle.other.is_empty());
+    assert_eq!(
+        serde_json::json!({
+            "id": "1",
+            "url": "https://opensubtitles.example/1.srt",
+            "lang": "eng"
+        }),
+        serde_json::to_value(&subtitle).unwrap()
+    );
+}
+
+/// The add-on specific properties are serialized back out, so that a
+/// round-trip through the core does not lose them.
+#[test]
+fn subtitles_add_on_specific_properties_round_trip() {
+    let json = serde_json::json!({
+        "id": "1",
+        "url": "https://opensubtitles.example/1.srt",
+        "lang": "eng",
+        "label": "English (GROUP)",
+        "subtitleFileName": "Movie.2009.1080p.BluRay.x264-GROUP.srt",
+        "releaseGroup": "GROUP",
+        "fpsMilli": 23976
+    });
+
+    let subtitle = serde_json::from_value::<Subtitles>(json.clone()).unwrap();
+    assert_eq!(json, serde_json::to_value(&subtitle).unwrap());
+    assert_eq!(
+        subtitle,
+        serde_json::from_value::<Subtitles>(serde_json::to_value(&subtitle).unwrap()).unwrap()
     );
 }


### PR DESCRIPTION
The addon protocol only specifies `id`, `url` and `lang` for a subtitle object, but add-ons routinely send more. The OpenSubtitles v3 add-on, for instance, attaches `subtitleFileName`, `movieReleaseName`, `releaseGroup` and `fpsMilli` to every entry, and `SubEncoding` is not modelled either. All of it is currently discarded by serde, so a client cannot tell fifteen English uploads apart, cannot label them by release group, and cannot warn that a 25 fps subtitle will drift against a 23.976 fps video.

Rather than blessing one add-on's property names with dedicated fields, collect whatever else was sent into a flattened catch-all, the same way `StreamBehaviorHints::other` and `MetaItemBehaviorHints::other` already do. The properties are serialized back out, so they reach the UI through `stremio-core-web`'s player serializer without any change there.

This is additive: known fields are unaffected, a subtitle without extra properties round-trips to exactly the same JSON as before, and `Default` still works. The only visible difference is that `Subtitles` now (de)serializes as a map instead of a struct, which is what `#[serde(flatten)]` requires and which the serde_test tokens are updated for.

Deliberately limited to `Subtitles`: `Stream` and `MetaItem` drop add-on properties in the same way and deserve the same treatment, but they are larger types with more construction sites and deep-link encoding to think about, so they are better served by follow-ups than by widening this change.

This MR was created by asking my friendly Opus 5 agent to solve this issue.