### PR TITLE
Reject non-http streaming server URLs

### DIFF
--- a/src/models/ctx/error.rs
+++ b/src/models/ctx/error.rs
@@ -40,6 +40,7 @@ pub enum OtherError {
     AddonConfigurationRequired,
     UserAddonsAreLocked,
     UserLibraryIsMissing,
+    InvalidStreamingServerUrl,
 }
 
 impl OtherError {
@@ -53,6 +54,7 @@ impl OtherError {
             OtherError::AddonConfigurationRequired => "Addon requires configuration".to_owned(),
             OtherError::UserAddonsAreLocked => "Fetching Addons from the API failed and we have defaulted the addons to the officials ones until the request succeeds".to_owned(),
             OtherError::UserLibraryIsMissing => "Fetching Library from the API failed and we have defaulted to empty library until the request succeeds".to_owned(),
+            OtherError::InvalidStreamingServerUrl => "Streaming server URL must be http or https".to_owned(),
         }
     }
     pub fn code(&self) -> u64 {
@@ -65,6 +67,7 @@ impl OtherError {
             OtherError::AddonConfigurationRequired => 6,
             OtherError::UserAddonsAreLocked => 7,
             OtherError::UserLibraryIsMissing => 8,
+            OtherError::InvalidStreamingServerUrl => 9,
         }
     }
 }

--- a/src/models/ctx/update_profile.rs
+++ b/src/models/ctx/update_profile.rs
@@ -239,7 +239,15 @@ pub fn update_profile<E: Env + 'static>(
             .unchanged(),
         },
         Msg::Action(Action::Ctx(ActionCtx::UpdateSettings(settings))) => {
-            if profile.settings != *settings {
+            if !matches!(settings.streaming_server_url.scheme(), "http" | "https") {
+                Effects::msg(Msg::Event(Event::Error {
+                    error: CtxError::from(OtherError::InvalidStreamingServerUrl),
+                    source: Box::new(Event::SettingsUpdated {
+                        settings: settings.to_owned(),
+                    }),
+                }))
+                .unchanged()
+            } else if profile.settings != *settings {
                 settings.clone_into(&mut profile.settings);
                 Effects::msg(Msg::Event(Event::SettingsUpdated {
                     settings: settings.to_owned(),

--- a/src/unit_tests/ctx/update_settings.rs
+++ b/src/unit_tests/ctx/update_settings.rs
@@ -11,6 +11,7 @@ use crate::types::server_urls::ServerUrlsBucket;
 use crate::types::streams::StreamsBucket;
 use crate::unit_tests::{TestEnv, REQUESTS, STORAGE};
 use stremio_derive::Model;
+use url::Url;
 
 #[test]
 fn actionctx_updatesettings() {
@@ -117,6 +118,49 @@ fn actionctx_updatesettings_not_changed() {
             .is_some_and(|data| {
                 serde_json::from_str::<Profile>(data).unwrap().settings == settings
             }),
+        "Settings not updated in storage"
+    );
+    assert!(
+        REQUESTS.read().unwrap().is_empty(),
+        "No requests have been sent"
+    );
+}
+
+#[test]
+fn actionctx_updatesettings_invalid_streaming_server_url() {
+    #[derive(Model, Clone, Default)]
+    #[model(TestEnv)]
+    struct TestModel {
+        ctx: Ctx,
+    }
+    let settings = Settings {
+        streaming_server_url: Url::parse("javascript:x").unwrap(),
+        ..Settings::default()
+    };
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    let ctx = Ctx::new(
+        Profile::default(),
+        LibraryBucket::default(),
+        StreamsBucket::default(),
+        ServerUrlsBucket::new::<TestEnv>(None),
+        NotificationsBucket::new::<TestEnv>(None, vec![]),
+        SearchHistoryBucket::default(),
+        DismissedEventsBucket::default(),
+    );
+    let (runtime, _rx) = Runtime::<TestEnv, _>::new(TestModel { ctx }, vec![], 1000);
+    TestEnv::run(|| {
+        runtime.dispatch(RuntimeAction {
+            field: None,
+            action: Action::Ctx(ActionCtx::UpdateSettings(settings)),
+        })
+    });
+    assert_eq!(
+        runtime.model().unwrap().ctx.profile.settings,
+        Settings::default(),
+        "Settings not updated in memory"
+    );
+    assert!(
+        STORAGE.read().unwrap().get(PROFILE_STORAGE_KEY).is_none(),
         "Settings not updated in storage"
     );
     assert!(


### PR DESCRIPTION
`UpdateSettings` accepted any `Url` for `streaming_server_url`, so `?streamingServerUrl=javascript:x` on web made `get_settings` panic on `join` and the wasm worker died until reload.

Non-http(s) URLs are now rejected with an error event and the profile is left untouched. Web side is Stremio/stremio-web#1414.