### PR TITLE
fix(addons): persist post-redirect transport URL for URL-shortener addons

### DIFF
--- a/src/addon_transport/addon_transport.rs
+++ b/src/addon_transport/addon_transport.rs
@@ -1,7 +1,8 @@
 use crate::runtime::TryEnvFuture;
 use crate::types::addon::{Manifest, ResourcePath, ResourceResponse};
+use url::Url;
 
 pub trait AddonTransport {
     fn resource(&self, path: &ResourcePath) -> TryEnvFuture<ResourceResponse>;
-    fn manifest(&self) -> TryEnvFuture<Manifest>;
+    fn manifest(&self) -> TryEnvFuture<(Manifest, Option<Url>)>;
 }

--- a/src/addon_transport/http_transport/http_transport.rs
+++ b/src/addon_transport/http_transport/http_transport.rs
@@ -96,7 +96,7 @@ impl<E: Env> AddonTransport for AddonHTTPTransport<E> {
         let request = Request::get(url).body(()).expect("request builder failed");
         E::fetch(request)
     }
-    fn manifest(&self) -> TryEnvFuture<Manifest> {
+    fn manifest(&self) -> TryEnvFuture<(Manifest, Option<Url>)> {
         if self.transport_url.path().ends_with(ADDON_LEGACY_PATH) {
             return AddonLegacyTransport::<E>::new(&self.transport_url).manifest();
         }
@@ -104,6 +104,6 @@ impl<E: Env> AddonTransport for AddonHTTPTransport<E> {
         let request = Request::get(self.transport_url.as_str())
             .body(())
             .expect("request builder failed");
-        E::fetch(request)
+        E::fetch_with_url(request)
     }
 }

--- a/src/addon_transport/http_transport/legacy/mod.rs
+++ b/src/addon_transport/http_transport/legacy/mod.rs
@@ -141,12 +141,14 @@ impl<T: Env> AddonTransport for AddonLegacyTransport<'_, T> {
             _ => future::err(LegacyErr::UnsupportedResource.into()).boxed_env(),
         }
     }
-    fn manifest(&self) -> TryEnvFuture<Manifest> {
+    fn manifest(&self) -> TryEnvFuture<(Manifest, Option<Url>)> {
         let url = format!("{}/q.json?b={}", self.transport_url, MANIFEST_REQUEST_PARAM);
         let r = Request::get(url).body(()).expect("request builder failed");
-        T::fetch::<_, JsonRPCResp<LegacyManifestResp>>(r)
+        T::fetch_with_url::<_, JsonRPCResp<LegacyManifestResp>>(r)
+            .map_ok(|(resp, _)| resp)
             .and_then(map_response)
             .map_ok(Into::into)
+            .map_ok(|manifest| (manifest, None))
             .boxed_env()
     }
 }

--- a/src/addon_transport/unsupported_transport.rs
+++ b/src/addon_transport/unsupported_transport.rs
@@ -25,7 +25,7 @@ impl AddonTransport for UnsupportedTransport {
     fn resource(&self, _path: &ResourcePath) -> TryEnvFuture<ResourceResponse> {
         self.result::<ResourceResponse>()
     }
-    fn manifest(&self) -> TryEnvFuture<Manifest> {
-        self.result::<Manifest>()
+    fn manifest(&self) -> TryEnvFuture<(Manifest, Option<Url>)> {
+        self.result::<(Manifest, Option<Url>)>()
     }
 }

--- a/src/models/addon_details.rs
+++ b/src/models/addon_details.rs
@@ -62,15 +62,18 @@ impl<E: Env + 'static> UpdateWithCtx<E> for AddonDetails {
                     .join(local_addon_effects)
                     .join(remote_addon_effects)
             }
-            Msg::Internal(Internal::ManifestRequestResult(transport_url, result)) => {
-                descriptor_update::<E>(
-                    &mut self.remote_addon,
-                    DescriptorAction::ManifestRequestResult {
-                        transport_url,
-                        result,
-                    },
-                )
-            }
+            Msg::Internal(Internal::ManifestRequestResult {
+                transport_url,
+                resolved_transport_url,
+                result,
+            }) => descriptor_update::<E>(
+                &mut self.remote_addon,
+                DescriptorAction::ManifestRequestResult {
+                    transport_url,
+                    resolved_transport_url,
+                    result,
+                },
+            ),
             Msg::Internal(Internal::ProfileChanged) => {
                 local_addon_update(&mut self.local_addon, &self.selected, &ctx.profile)
             }

--- a/src/models/common/descriptor_loadable.rs
+++ b/src/models/common/descriptor_loadable.rs
@@ -1,4 +1,4 @@
-use crate::constants::OFFICIAL_ADDONS;
+use crate::constants::{ADDON_LEGACY_PATH, ADDON_MANIFEST_PATH, OFFICIAL_ADDONS};
 use crate::models::common::Loadable;
 use crate::runtime::msg::{Internal, Msg};
 use crate::runtime::{EffectFuture, Effects, Env, EnvError, EnvFutureExt};
@@ -23,6 +23,7 @@ pub enum DescriptorAction<'a> {
     /// Loads the manifest for the addon of the [`Descriptor`]
     ManifestRequestResult {
         transport_url: &'a Url,
+        resolved_transport_url: &'a Option<Url>,
         result: &'a Result<Manifest, EnvError>,
     },
 }
@@ -49,8 +50,18 @@ pub fn descriptor_update<E: Env + 'static>(
                 Effects::future(EffectFuture::Concurrent(
                     E::addon_transport(&transport_url)
                         .manifest()
-                        .map(move |result| {
-                            Msg::Internal(Internal::ManifestRequestResult(transport_url, result))
+                        .map(move |manifest_result| {
+                            let (resolved_transport_url, result) = match manifest_result {
+                                Ok((manifest, resolved_transport_url)) => {
+                                    (resolved_transport_url, Ok(manifest))
+                                }
+                                Err(error) => (None, Err(error)),
+                            };
+                            Msg::Internal(Internal::ManifestRequestResult {
+                                transport_url: transport_url.to_owned(),
+                                resolved_transport_url,
+                                result,
+                            })
                         })
                         .boxed_env(),
                 ))
@@ -60,12 +71,14 @@ pub fn descriptor_update<E: Env + 'static>(
         }
         DescriptorAction::ManifestRequestResult {
             transport_url,
+            resolved_transport_url,
             result,
         } => match descriptor {
             Some(DescriptorLoadable {
                 transport_url: loading_transport_url,
                 content: Loadable::Loading,
             }) if loading_transport_url == transport_url => {
+                let transport_url = adopted_transport_url(transport_url, resolved_transport_url);
                 *descriptor = Some(DescriptorLoadable {
                     transport_url: transport_url.to_owned(),
                     content: match result {
@@ -75,7 +88,7 @@ pub fn descriptor_update<E: Env + 'static>(
                             // Only official addons have flags!
                             flags: OFFICIAL_ADDONS
                                 .iter()
-                                .find(|descriptor| descriptor.transport_url == *transport_url)
+                                .find(|descriptor| descriptor.transport_url == transport_url)
                                 .map(|descriptor| descriptor.flags.to_owned())
                                 .unwrap_or_default(),
                         }),
@@ -87,4 +100,19 @@ pub fn descriptor_update<E: Env + 'static>(
             _ => Effects::none().unchanged(),
         },
     }
+}
+
+/// Adopts the resolved (post-redirect) transport URL only if it points to a
+/// real addon endpoint (`/manifest.json` or `/stremio/v1`). Otherwise keeps the
+/// URL the user entered, guarding against shorteners that redirect somewhere
+/// unrelated.
+fn adopted_transport_url(transport_url: &Url, resolved_transport_url: &Option<Url>) -> Url {
+    resolved_transport_url
+        .as_ref()
+        .filter(|url| {
+            let path = url.path();
+            path.ends_with(ADDON_MANIFEST_PATH) || path.ends_with(ADDON_LEGACY_PATH)
+        })
+        .cloned()
+        .unwrap_or_else(|| transport_url.clone())
 }

--- a/src/models/ctx/update_trakt_addon.rs
+++ b/src/models/ctx/update_trakt_addon.rs
@@ -63,11 +63,16 @@ pub fn update_trakt_addon<E: Env + 'static>(
 
             trakt_uninstall_effects.join(eq_update(trakt_addon, None))
         }
-        Msg::Internal(Internal::ManifestRequestResult(transport_url, result)) => {
+        Msg::Internal(Internal::ManifestRequestResult {
+            transport_url,
+            resolved_transport_url,
+            result,
+        }) => {
             let trakt_addon_effects = descriptor_update::<E>(
                 trakt_addon,
                 DescriptorAction::ManifestRequestResult {
                     transport_url,
+                    resolved_transport_url,
                     result,
                 },
             );

--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -144,6 +144,23 @@ pub trait Env {
         request: Request<IN>,
     ) -> TryEnvFuture<OUT>;
 
+    /// Perform a fetch that also returns the final response URL (after any
+    /// redirects were followed).
+    ///
+    /// The default implementation returns `None` for the URL, keeping backward
+    /// compatibility: environments that only implement [`Env::fetch`] work as
+    /// before, just without redirect resolution.
+    fn fetch_with_url<
+        IN: Serialize + ConditionalSend + 'static,
+        OUT: for<'de> Deserialize<'de> + ConditionalSend + 'static,
+    >(
+        request: Request<IN>,
+    ) -> TryEnvFuture<(OUT, Option<Url>)> {
+        Self::fetch::<IN, OUT>(request)
+            .map_ok(|output| (output, None))
+            .boxed_env()
+    }
+
     fn get_storage<T: for<'de> Deserialize<'de> + ConditionalSend + 'static>(
         key: &str,
     ) -> TryEnvFuture<Option<T>>;

--- a/src/runtime/msg/internal.rs
+++ b/src/runtime/msg/internal.rs
@@ -144,7 +144,15 @@ pub enum Internal {
     /// Result for fetching resource from addons.
     ResourceRequestResult(ResourceRequest, Box<Result<ResourceResponse, EnvError>>),
     /// Result for fetching manifest from addon.
-    ManifestRequestResult(Url, Result<Manifest, EnvError>),
+    ///
+    /// Carries the requested `transport_url`, the resolved post-redirect URL (if any,
+    /// and only adopted when it looks like a real addon endpoint) and the manifest
+    /// fetch result.
+    ManifestRequestResult {
+        transport_url: Url,
+        resolved_transport_url: Option<Url>,
+        result: Result<Manifest, EnvError>,
+    },
     /// TODO: write some obvious comment about what it is
     NotificationsRequestResult(ResourceRequest, Box<Result<ResourceResponse, EnvError>>),
     /// Result for requesting a `dataExport` of user data.

--- a/src/unit_tests/env.rs
+++ b/src/unit_tests/env.rs
@@ -16,6 +16,8 @@ use crate::{
     runtime::{Env, EnvFuture, EnvFutureExt, Model, Runtime, RuntimeEvent, TryEnvFuture},
 };
 
+use url::Url;
+
 pub static FETCH_HANDLER: Lazy<RwLock<FetchHandler>> =
     Lazy::new(|| RwLock::new(Box::new(default_fetch_handler)));
 pub static REQUESTS: Lazy<RwLock<Vec<Request>>> = Lazy::new(Default::default);
@@ -27,6 +29,7 @@ pub static STATES: Lazy<RwLock<Vec<Box<dyn Any + Send + Sync + 'static>>>> =
 pub static NOW: Lazy<RwLock<DateTime<Utc>>> = Lazy::new(|| RwLock::new(Utc::now()));
 pub static LOCAL_TIMEZONE_OFFSET: Lazy<RwLock<FixedOffset>> =
     Lazy::new(|| RwLock::new(FixedOffset::east_opt(0).unwrap()));
+pub static RESOLVED_URLS: Lazy<RwLock<HashMap<String, String>>> = Lazy::new(Default::default);
 pub static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
 pub type FetchHandler =
@@ -69,6 +72,7 @@ impl TestEnv {
         *STATES.write().unwrap() = vec![];
         *NOW.write().unwrap() = Utc::now();
         *LOCAL_TIMEZONE_OFFSET.write().unwrap() = FixedOffset::east_opt(0).unwrap();
+        *RESOLVED_URLS.write().unwrap() = HashMap::new();
         env_mutex
     }
     pub fn run<F: FnOnce()>(runnable: F) {
@@ -119,6 +123,23 @@ impl Env for TestEnv {
                 *resp
                     .downcast::<OUT>()
                     .unwrap_or_else(|_| panic!("Failed to downcast to {}", type_name::<OUT>()))
+            })
+            .boxed_env()
+    }
+    fn fetch_with_url<IN: Serialize + 'static, OUT: for<'de> Deserialize<'de> + 'static>(
+        request: http::Request<IN>,
+    ) -> TryEnvFuture<(OUT, Option<Url>)> {
+        let request = Request::from(request);
+        REQUESTS.write().unwrap().push(request.to_owned());
+        let resolved_url = RESOLVED_URLS.read().unwrap().get(&request.url).cloned();
+        FETCH_HANDLER.read().unwrap()(request)
+            .map_ok(move |resp| {
+                let output = *resp
+                    .downcast::<OUT>()
+                    .unwrap_or_else(|_| panic!("Failed to downcast to {}", type_name::<OUT>()));
+                let resolved_url =
+                    resolved_url.map(|url| Url::parse(&url).expect("resolved url parse failed"));
+                (output, resolved_url)
             })
             .boxed_env()
     }

--- a/src/unit_tests/mod.rs
+++ b/src/unit_tests/mod.rs
@@ -8,6 +8,7 @@ mod data_export;
 mod deep_links;
 mod link;
 mod meta_details;
+mod models;
 mod player;
 mod serde;
 mod streaming_server;

--- a/src/unit_tests/models/addon_details.rs
+++ b/src/unit_tests/models/addon_details.rs
@@ -1,0 +1,103 @@
+use std::any::Any;
+use std::sync::{Arc, RwLock};
+
+use enclose::enclose;
+use futures::future;
+use stremio_derive::Model;
+use url::Url;
+
+use crate::{
+    models::{
+        addon_details::{AddonDetails, Selected},
+        common::{DescriptorLoadable, Loadable},
+        ctx::Ctx,
+    },
+    runtime::{msg::Action, EnvFutureExt, Runtime, RuntimeAction, TryEnvFuture},
+    types::addon::Manifest,
+    unit_tests::{default_fetch_handler, Request, TestEnv, FETCH_HANDLER, RESOLVED_URLS, STATES},
+};
+
+const SHORTENER: &str = "https://short.url/abc";
+const REAL_ADDON: &str = "https://addon.example/manifest.json";
+
+#[derive(Model, Default, Clone, Debug)]
+#[model(TestEnv)]
+struct TestModel {
+    ctx: Ctx,
+    addon_details: AddonDetails,
+}
+
+fn fetch_handler(request: Request) -> TryEnvFuture<Box<dyn Any + Send>> {
+    if request.url == SHORTENER {
+        future::ok(Box::new(Manifest::default()) as Box<dyn Any + Send>).boxed_env()
+    } else {
+        default_fetch_handler(request)
+    }
+}
+
+/// Dispatch a `Load(AddonDetails)` for the shortener URL, run the runtime and
+/// collect the model states via `STATES`.
+fn run_with_transport(resolved: Option<&str>) {
+    let _env_mutex = TestEnv::reset().expect("Should have exclusive lock to TestEnv");
+    *FETCH_HANDLER.write().unwrap() = Box::new(fetch_handler);
+    if let Some(resolved) = resolved {
+        RESOLVED_URLS
+            .write()
+            .unwrap()
+            .insert(SHORTENER.to_owned(), resolved.to_owned());
+    }
+
+    let (runtime, rx) = Runtime::<TestEnv, _>::new(TestModel::default(), vec![], 1000);
+    let runtime = Arc::new(RwLock::new(runtime));
+    TestEnv::run_with_runtime(
+        rx,
+        runtime.clone(),
+        enclose!((runtime) move || {
+            let runtime = runtime.read().unwrap();
+            runtime.dispatch(RuntimeAction {
+                field: None,
+                action: Action::Load(crate::runtime::msg::ActionLoad::AddonDetails(
+                    Selected {
+                        transport_url: Url::parse(SHORTENER).unwrap(),
+                    },
+                )),
+            });
+        }),
+    );
+}
+
+/// Returns the `remote_addon` `transport_url` from the last collected state.
+fn last_transport_url() -> String {
+    let states = STATES.read().unwrap();
+    let states = states
+        .iter()
+        .map(|state| state.downcast_ref::<TestModel>().unwrap())
+        .collect::<Vec<_>>();
+    let last = states.last().expect("expected at least one state");
+    match &last.addon_details.remote_addon {
+        Some(DescriptorLoadable {
+            transport_url,
+            content: Loadable::Ready(..),
+            ..
+        }) => transport_url.to_string(),
+        _ => panic!("expected a Ready remote addon"),
+    }
+}
+
+#[test]
+fn resolves_shortener_redirect_and_adopts_transport_url() {
+    run_with_transport(Some(REAL_ADDON));
+    assert_eq!(last_transport_url(), REAL_ADDON);
+}
+
+#[test]
+fn without_redirect_keeps_entered_url() {
+    run_with_transport(None);
+    assert_eq!(last_transport_url(), SHORTENER);
+}
+
+#[test]
+fn ignores_redirect_with_invalid_suffix() {
+    run_with_transport(Some("https://evil.example/not_an_addon"));
+    assert_eq!(last_transport_url(), SHORTENER);
+}

--- a/src/unit_tests/models/mod.rs
+++ b/src/unit_tests/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod addon_details;

--- a/stremio-core-web/src/env.rs
+++ b/stremio-core-web/src/env.rs
@@ -278,6 +278,16 @@ impl WebEnv {
 impl Env for WebEnv {
     fn fetch<IN, OUT>(request: Request<IN>) -> TryEnvFuture<OUT>
     where
+        IN: Serialize + 'static,
+        for<'de> OUT: Deserialize<'de> + 'static,
+    {
+        Self::fetch_with_url::<IN, OUT>(request)
+            .map_ok(|(output, _)| output)
+            .boxed_local()
+    }
+
+    fn fetch_with_url<IN, OUT>(request: Request<IN>) -> TryEnvFuture<(OUT, Option<Url>)>
+    where
         IN: Serialize,
         for<'de> OUT: Deserialize<'de> + 'static,
     {
@@ -352,6 +362,7 @@ impl Env for WebEnv {
             let resp = resp
                 .dyn_into::<web_sys::Response>()
                 .expect("WebEnv::fetch: Response into web_sys::Response failed to be built");
+            let response_url = resp.url().parse::<Url>().ok();
             // status check and JSON extraction from response.
             let resp = if ![200, 201].contains(&resp.status()) {
                 return Err(EnvError::Fetch(format!(
@@ -386,7 +397,7 @@ impl Env for WebEnv {
                 })?
             };
 
-            response_deserialize(resp)
+            Ok((response_deserialize(resp)?, response_url))
         }
         .boxed_local()
     }


### PR DESCRIPTION
## Problem

Addons installed via a URL shortener (e.g. `https://short.url/xyz`) install successfully but never load streams/torrents. The shortened URL does not end in `/manifest.json`, so every subsequent `resource()` request gets rejected by the core's transport check even though the manifest fetch itself works (the server follows the redirect and serves the manifest).

Related issue: Stremio/stremio-bugs#2779

## Solution

Resolve the redirect once, at manifest-fetch time, and persist the final post-redirect URL as the addon's `transport_url` so later `resource()` requests pass the addon endpoint check.

- Add `Env::fetch_with_url<IN, OUT>` which returns `TryEnvFuture<(OUT, Option<Url>)>` — the resolved (post-redirect) response URL. The default implementation wraps `Env::fetch` and returns `None`, keeping existing environments backward compatible.
- `AddonTransport::manifest()` now returns `TryEnvFuture<(Manifest, Option<Url>)>`.
- `WebEnv` implements `fetch_with_url` using `Response::url()`.
- `descriptor_loadable` adopts the resolved URL as the `transport_url` only when its path ends with `ADDON_MANIFEST_PATH` (`/manifest.json`) or `ADDON_LEGACY_PATH` (`/stremio/v1`), guarding against shorteners that redirect somewhere unrelated.
- The resolved URL is persisted both on `DescriptorLoadable.transport_url` and `Descriptor.transport_url`.

## Verification

- `cargo test` — 241 passed (238 existing + 3 new)
- `cargo clippy --all --no-deps -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `git diff --check` — clean
- `cargo check --target wasm32-unknown-unknown -p stremio-core-web` — ok

New unit tests cover: adopting the resolved URL on a valid redirect, keeping the entered URL when there is no redirect, and ignoring redirects with invalid suffixes.

No storage format changes (`SCHEMA_VERSION` untouched) — only the behavior of the existing `transport_url` field changes.